### PR TITLE
Give parcel geometry an interface, and extract the proximity search

### DIFF
--- a/counties/brazos/adapter.py
+++ b/counties/brazos/adapter.py
@@ -36,6 +36,7 @@ from counties.common.contracts import (
     SearchField,
     Subject,
 )
+from counties.common.geometry import accounts_with_coordinates, coordinates_for
 from counties.common.history import assessment_history_rows
 from counties.common.tax_impact import calculate_tax_impact
 
@@ -144,8 +145,6 @@ class BrazosAdapter(CountyAdapter):
         if not records:
             return []
 
-        from counties.common.tax_models import ParcelGeometry
-
         # No FK from PropertyAccount to PropertyLand (both key on a plain
         # prop_id string), so land totals are merged in manually.
         year = records[0].tax_year
@@ -157,20 +156,12 @@ class BrazosAdapter(CountyAdapter):
             .annotate(total_land_value=Sum("land_value"), total_acreage=Sum("acreage"))
         }
 
-        # Bulk-fetch coordinates to determine has_location for each row.
-        accts_with_coords = set(
-            ParcelGeometry.objects.filter(
-                account_number__in=prop_ids,
-                county="brazos",
-                latitude__isnull=False,
-                longitude__isnull=False,
-            ).values_list("account_number", flat=True)
-        )
+        located = accounts_with_coordinates(prop_ids, county="brazos")
 
         rows = []
         for account in records:
             land = land_by_prop.get(account.prop_id, {})
-            has_location = account.prop_id in accts_with_coords
+            has_location = account.prop_id in located
             rows.append(
                 {
                     "prop_id": account.prop_id,
@@ -216,11 +207,7 @@ class BrazosAdapter(CountyAdapter):
         if account.situs_zip:
             locality = f"{locality} {account.situs_zip}".strip()
 
-        from counties.common.tax_models import ParcelGeometry
-
-        geom = ParcelGeometry.objects.filter(
-            account_number=account.prop_id, county="brazos"
-        ).first()
+        location = coordinates_for(account.prop_id, county="brazos")
 
         return Subject(
             key=account.prop_id,
@@ -234,7 +221,7 @@ class BrazosAdapter(CountyAdapter):
             bathrooms=building.bathrooms if building else None,
             year_built=year_built,
             features=_format_feature_list(features),
-            has_location=bool(geom and geom.latitude and geom.longitude),
+            has_location=location is not None,
             tax_year=year,
             detail_rows=detail_rows,
         )

--- a/counties/brazos/similarity.py
+++ b/counties/brazos/similarity.py
@@ -504,19 +504,20 @@ def find_similar_properties(
     data/similarity.py::find_similar_properties's DB-side haversine
     bounding-box approach against ParcelGeometry, then joins back to
     PropertyAccount by prop_id."""
+    from counties.common.geometry import coordinates_for
     from counties.common.tax_models import ParcelGeometry
 
     target = PropertyAccount.objects.order_by("-tax_year").filter(prop_id=prop_id).first()
     if not target:
         return []
 
-    target_geom = ParcelGeometry.objects.filter(account_number=prop_id, county="brazos").first()
-    if not target_geom or not target_geom.latitude or not target_geom.longitude:
+    location = coordinates_for(prop_id, county="brazos")
+    if location is None:
         return []
 
     tax_year = target.tax_year
-    target_lat = float(target_geom.latitude)
-    target_lon = float(target_geom.longitude)
+    target_lat = float(location.latitude)
+    target_lon = float(location.longitude)
 
     target_improvement, target_building = _primary_improvement(prop_id, tax_year)
     target_features = list(PropertyExtraFeature.objects.filter(prop_id=prop_id, tax_year=tax_year))

--- a/counties/brazos/similarity.py
+++ b/counties/brazos/similarity.py
@@ -38,9 +38,6 @@ import re
 from collections import defaultdict
 from math import asin, cos, radians, sin, sqrt
 
-from django.db.models import ExpressionWrapper, F, FloatField, Value
-from django.db.models.functions import ACos, Cos, Greatest, Least, Radians, Sin
-
 from .models import (
     PropertyAccount,
     PropertyBuildingCharacteristic,
@@ -49,11 +46,6 @@ from .models import (
     PropertyImprovementDetail,
     PropertyLand,
 )
-
-# How many nearest parcels find_similar_properties() pulls out of the database
-# to score in Python. Every one of these slots must buy a scoreable comp, which
-# is why the PropertyAccount filter is applied before the cap, not after.
-MAX_GEOMETRY_CANDIDATES = 2000
 
 RESIDENTIAL_WEIGHTS = {
     "living_area": 24.0,
@@ -504,8 +496,7 @@ def find_similar_properties(
     data/similarity.py::find_similar_properties's DB-side haversine
     bounding-box approach against ParcelGeometry, then joins back to
     PropertyAccount by prop_id."""
-    from counties.common.geometry import coordinates_for
-    from counties.common.tax_models import ParcelGeometry
+    from counties.common.geometry import coordinates_for, nearest_parcels
 
     target = PropertyAccount.objects.order_by("-tax_year").filter(prop_id=prop_id).first()
     if not target:
@@ -523,62 +514,21 @@ def find_similar_properties(
     target_features = list(PropertyExtraFeature.objects.filter(prop_id=prop_id, tax_year=tax_year))
     target_acreage = _total_acreage(prop_id, tax_year)
 
-    lat_range = max_distance_miles / 69.0
-    lon_range = max_distance_miles / (69.0 * cos(radians(target_lat)))
-    min_lat, max_lat = target_lat - lat_range, target_lat + lat_range
-    min_lon, max_lon = target_lon - lon_range, target_lon + lon_range
-
-    geom_candidates = ParcelGeometry.objects.filter(
+    # Restrict to parcels that have a PropertyAccount row for this year:
+    # ParcelGeometry is keyed by prop_id alone and carries no tax_year, so
+    # without this a parcel absent from `tax_year` would take a candidate slot
+    # and then vanish at the join below.
+    distance_map = nearest_parcels(
+        location,
         county="brazos",
-        latitude__gte=min_lat,
-        latitude__lte=max_lat,
-        longitude__gte=min_lon,
-        longitude__lte=max_lon,
-        latitude__isnull=False,
-        longitude__isnull=False,
-    ).exclude(account_number=prop_id)
-
-    # Restrict to parcels with a PropertyAccount row for this year, before the
-    # cap below rather than after. ParcelGeometry is keyed by prop_id alone --
-    # it carries no tax_year and holds every parcel in the shapefile -- so
-    # without this, geometry for a parcel absent from `tax_year` would consume
-    # a candidate slot and then vanish at the join, shrinking the comp pool.
-    geom_candidates = geom_candidates.filter(
-        account_number__in=PropertyAccount.objects.filter(tax_year=tax_year).values("prop_id")
+        within_miles=max_distance_miles,
+        backed_by=PropertyAccount.objects.filter(tax_year=tax_year).values("prop_id"),
+        exclude_account=prop_id,
     )
-
-    target_lat_rad = radians(target_lat)
-    target_lon_rad = radians(target_lon)
-
-    geom_candidates = (
-        geom_candidates.annotate(
-            distance=ExpressionWrapper(
-                3959.0
-                * ACos(
-                    Least(
-                        1.0,
-                        Greatest(
-                            -1.0,
-                            Cos(Value(target_lat_rad))
-                            * Cos(Radians(F("latitude")))
-                            * Cos(Radians(F("longitude")) - Value(target_lon_rad))
-                            + Sin(Value(target_lat_rad)) * Sin(Radians(F("latitude"))),
-                        ),
-                    )
-                ),
-                output_field=FloatField(),
-            )
-        )
-        .filter(distance__lte=max_distance_miles)
-        .order_by("distance")[:MAX_GEOMETRY_CANDIDATES]
-    )
-
-    geom_list = list(geom_candidates.values("account_number", "distance"))
-    if not geom_list:
+    if not distance_map:
         return []
 
-    candidate_prop_ids = [g["account_number"] for g in geom_list]
-    distance_map = {g["account_number"]: g["distance"] for g in geom_list}
+    candidate_prop_ids = list(distance_map)
 
     candidate_list = list(
         PropertyAccount.objects.filter(prop_id__in=candidate_prop_ids, tax_year=tax_year)

--- a/counties/brazos/tests/test_similarity.py
+++ b/counties/brazos/tests/test_similarity.py
@@ -388,7 +388,7 @@ class GeometryCandidateCapTests(TestCase):
             prop_id=self.COMP, tax_year=TAX_YEAR, land_seq=1, acreage=Decimal("0.25")
         )
 
-        with patch("counties.brazos.similarity.MAX_GEOMETRY_CANDIDATES", 1):
+        with patch("counties.common.geometry.MAX_NEARBY_PARCELS", 1):
             results = find_similar_properties(self.TARGET, min_score=0.0)
 
         self.assertEqual([r["property"].prop_id for r in results], [self.COMP])

--- a/counties/common/geometry.py
+++ b/counties/common/geometry.py
@@ -23,10 +23,29 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from decimal import Decimal
+from math import cos, radians
 
-from django.db.models import Exists, OuterRef
+from django.db.models import (
+    Exists,
+    ExpressionWrapper,
+    F,
+    FloatField,
+    OuterRef,
+    QuerySet,
+    Value,
+)
+from django.db.models.functions import ACos, Cos, Greatest, Least, Radians, Sin
 
 from .tax_models import ParcelGeometry
+
+# How many parcels a proximity search pulls out of the database to score in
+# Python. Every one of these slots has to buy a usable candidate, which is why
+# ``nearest_parcels`` requires ``backed_by`` rather than offering it.
+MAX_NEARBY_PARCELS = 2000
+
+# Miles per degree of latitude. Longitude degrees shrink with the cosine of the
+# latitude, which is why the longitude span is scaled below.
+_MILES_PER_DEGREE_LATITUDE = 69.0
 
 
 @dataclass(frozen=True)
@@ -101,3 +120,86 @@ def coordinates_exist(*, county: str, account_field: str = "account_number") -> 
             longitude__isnull=False,
         )
     )
+
+
+def nearest_parcels(
+    origin: Coordinates,
+    *,
+    county: str,
+    within_miles: float,
+    backed_by: QuerySet,
+    exclude_account: str | None = None,
+    limit: int | None = None,
+) -> dict[str, float]:
+    """Return the nearest parcels to ``origin``, as ``{account_number: miles}``.
+
+    Ordered nearest-first, capped at ``limit``. Both counties' comparables
+    searches are built on this; the haversine distance is computed in the
+    database and the bounding box that makes it indexable is an implementation
+    detail — callers say how far, not how to narrow.
+
+    ``backed_by`` is a queryset yielding the account numbers a parcel must
+    appear in to be considered: Harris passes properties (or buildings in a
+    size range), Brazos passes accounts for the target tax year. It is
+    **required, and applied before the cap**. ParcelGeometry holds every parcel
+    in the source shapefile, so on real Harris data 24% of rows have no
+    property behind them; capping first and filtering afterwards silently spent
+    37.6% of one sampled search's candidate slots on parcels that were then
+    discarded. Making the restriction a required argument is what stops that
+    from being expressible.
+    """
+    # Resolved here rather than as a default argument: a default binds at
+    # definition time, which would make MAX_NEARBY_PARCELS unpatchable and
+    # quietly turn the cap regression tests into no-ops.
+    if limit is None:
+        limit = MAX_NEARBY_PARCELS
+
+    latitude = float(origin.latitude)
+    longitude = float(origin.longitude)
+
+    latitude_span = within_miles / _MILES_PER_DEGREE_LATITUDE
+    longitude_span = within_miles / (_MILES_PER_DEGREE_LATITUDE * cos(radians(latitude)))
+
+    candidates = ParcelGeometry.objects.filter(
+        county=county,
+        latitude__gte=latitude - latitude_span,
+        latitude__lte=latitude + latitude_span,
+        longitude__gte=longitude - longitude_span,
+        longitude__lte=longitude + longitude_span,
+        latitude__isnull=False,
+        longitude__isnull=False,
+    ).filter(account_number__in=backed_by)
+
+    if exclude_account is not None:
+        candidates = candidates.exclude(account_number=exclude_account)
+
+    origin_latitude = radians(latitude)
+    origin_longitude = radians(longitude)
+
+    # Great-circle distance in miles. Least/Greatest clamp the cosine into
+    # [-1, 1]: floating-point drift can push it just outside, and ACos of that
+    # is a database error rather than a rounding nuisance.
+    distance = ExpressionWrapper(
+        3959.0
+        * ACos(
+            Least(
+                1.0,
+                Greatest(
+                    -1.0,
+                    Cos(Value(origin_latitude))
+                    * Cos(Radians(F("latitude")))
+                    * Cos(Radians(F("longitude")) - Value(origin_longitude))
+                    + Sin(Value(origin_latitude)) * Sin(Radians(F("latitude"))),
+                ),
+            )
+        ),
+        output_field=FloatField(),
+    )
+
+    rows = (
+        candidates.annotate(distance=distance)
+        .filter(distance__lte=within_miles)
+        .order_by("distance")[:limit]
+        .values_list("account_number", "distance")
+    )
+    return dict(rows)

--- a/counties/common/geometry.py
+++ b/counties/common/geometry.py
@@ -1,0 +1,103 @@
+"""Reading parcel coordinates.
+
+``ParcelGeometry`` is a county-scoped table keyed by account number, and using
+it correctly means knowing several things that are easy to get wrong and easy
+to get *inconsistently* right:
+
+- every query has to be scoped by ``county``; the table holds all of them
+- ``latitude`` and ``longitude`` are independently nullable, so "a row exists"
+  and "coordinates are known" are different questions
+- rows are keyed by an account-number *string*, not a foreign key, so there is
+  no ORM traversal from a property to its geometry
+- the table holds every parcel in the source shapefile, including ones with no
+  property behind them, so a bare geometry query is not a property query
+
+Callers ask questions here instead of building those filters themselves. The
+one caller left reaching past this module is the Postgres branch of
+``etl_pipeline.readiness``, which needs the same predicate inside raw SQL, and
+the two GIS loaders, which write rather than read.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from decimal import Decimal
+
+from django.db.models import Exists, OuterRef
+
+from .tax_models import ParcelGeometry
+
+
+@dataclass(frozen=True)
+class Coordinates:
+    """A parcel's location. Both values are always present."""
+
+    latitude: Decimal
+    longitude: Decimal
+
+
+def coordinates_for(account_number: str, *, county: str) -> Coordinates | None:
+    """Return the account's coordinates, or None if they aren't known.
+
+    A missing row and a row whose latitude or longitude is NULL are the same
+    answer to the caller, so both collapse to None.
+    """
+    row = (
+        ParcelGeometry.objects.filter(
+            account_number=account_number,
+            county=county,
+            latitude__isnull=False,
+            longitude__isnull=False,
+        )
+        .values_list("latitude", "longitude")
+        .first()
+    )
+    if row is None:
+        return None
+    return Coordinates(latitude=row[0], longitude=row[1])
+
+
+def accounts_with_coordinates(account_numbers: Iterable[str], *, county: str) -> set[str]:
+    """Return the subset of ``account_numbers`` that have known coordinates.
+
+    Takes an explicit account list rather than offering to fetch every account
+    in the county: the tables run to millions of rows, and materialising all of
+    them into Python is a mistake this interface should not make available.
+    Use :func:`coordinates_exist` to ask the same question in SQL.
+    """
+    accounts = list(account_numbers)
+    if not accounts:
+        return set()
+    return set(
+        ParcelGeometry.objects.filter(
+            account_number__in=accounts,
+            county=county,
+            latitude__isnull=False,
+            longitude__isnull=False,
+        ).values_list("account_number", flat=True)
+    )
+
+
+def coordinates_exist(*, county: str, account_field: str = "account_number") -> Exists:
+    """An ``Exists`` for "this row's account has coordinates", for use in a queryset.
+
+    Deliberately an ``Exists`` rather than ``account_number__in=<queryset>``.
+    Django renders the ``__in`` form as ``IN (subquery)`` and its negation as
+    ``NOT IN (subquery)``; ``NOT IN`` has to honour SQL's three-valued logic, so
+    Postgres cannot use a hash anti-join and re-checks the subquery per row.
+    Measured against 1.17M properties and 1.55M parcels, the ``NOT IN`` form ran
+    for over an hour without completing where ``NOT EXISTS`` returns in ~470ms.
+
+    ``account_field`` names the column on the *outer* model holding the account
+    number — ``account_number`` on Harris's PropertyRecord, ``prop_id`` on
+    Brazos's PropertyAccount.
+    """
+    return Exists(
+        ParcelGeometry.objects.filter(
+            account_number=OuterRef(account_field),
+            county=county,
+            latitude__isnull=False,
+            longitude__isnull=False,
+        )
+    )

--- a/counties/common/tests/test_geometry.py
+++ b/counties/common/tests/test_geometry.py
@@ -1,0 +1,130 @@
+"""Tests for counties/common/geometry.py.
+
+The facts these pin are the ones every caller previously had to re-derive:
+county scoping, the difference between "no row" and "row with null
+coordinates", and that the SQL form is an anti-join rather than NOT IN.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.test import TestCase
+
+from counties.common.geometry import (
+    Coordinates,
+    accounts_with_coordinates,
+    coordinates_exist,
+    coordinates_for,
+)
+from counties.common.tax_models import ParcelGeometry
+from counties.harris.models import PropertyRecord
+
+
+def _geometry(account_number, *, county="harris", latitude="29.76", longitude="-95.37"):
+    return ParcelGeometry.objects.create(
+        account_number=account_number,
+        county=county,
+        latitude=Decimal(latitude) if latitude is not None else None,
+        longitude=Decimal(longitude) if longitude is not None else None,
+    )
+
+
+class CoordinatesForTests(TestCase):
+    def test_returns_coordinates_for_a_known_account(self) -> None:
+        _geometry("ACCT1")
+
+        location = coordinates_for("ACCT1", county="harris")
+
+        self.assertEqual(location, Coordinates(Decimal("29.7600000"), Decimal("-95.3700000")))
+
+    def test_unknown_account_is_none(self) -> None:
+        self.assertIsNone(coordinates_for("NOPE", county="harris"))
+
+    def test_row_with_null_coordinates_is_none(self) -> None:
+        # A row exists, but the coordinates are not known -- to a caller that is
+        # the same answer as no row at all, so it must not leak through as a
+        # record with None fields.
+        _geometry("ACCT1", latitude=None, longitude=None)
+
+        self.assertIsNone(coordinates_for("ACCT1", county="harris"))
+
+    def test_half_populated_row_is_none(self) -> None:
+        _geometry("ACCT1", longitude=None)
+
+        self.assertIsNone(coordinates_for("ACCT1", county="harris"))
+
+    def test_county_scopes_the_lookup(self) -> None:
+        _geometry("SHARED", county="brazos")
+
+        self.assertIsNone(coordinates_for("SHARED", county="harris"))
+        self.assertIsNotNone(coordinates_for("SHARED", county="brazos"))
+
+
+class AccountsWithCoordinatesTests(TestCase):
+    def test_returns_only_the_accounts_that_have_coordinates(self) -> None:
+        _geometry("HAS1")
+        _geometry("HAS2")
+        _geometry("NULLED", latitude=None, longitude=None)
+
+        found = accounts_with_coordinates(["HAS1", "HAS2", "NULLED", "ABSENT"], county="harris")
+
+        self.assertEqual(found, {"HAS1", "HAS2"})
+
+    def test_empty_input_returns_empty_without_querying(self) -> None:
+        _geometry("HAS1")
+
+        with self.assertNumQueries(0):
+            self.assertEqual(accounts_with_coordinates([], county="harris"), set())
+
+    def test_county_scopes_the_lookup(self) -> None:
+        _geometry("SHARED", county="brazos")
+
+        self.assertEqual(accounts_with_coordinates(["SHARED"], county="harris"), set())
+        self.assertEqual(accounts_with_coordinates(["SHARED"], county="brazos"), {"SHARED"})
+
+
+class CoordinatesExistTests(TestCase):
+    def setUp(self) -> None:
+        for account_number in ("WITH", "WITHOUT"):
+            PropertyRecord.objects.create(
+                address=f"{account_number} ST",
+                city="Houston",
+                zipcode="77001",
+                account_number=account_number,
+                state_class="A1",
+                is_residential=True,
+            )
+        _geometry("WITH")
+        _geometry("WITHOUT", latitude=None, longitude=None)
+
+    def test_filters_to_properties_that_have_coordinates(self) -> None:
+        found = PropertyRecord.objects.filter(coordinates_exist(county="harris"))
+
+        self.assertEqual([p.account_number for p in found], ["WITH"])
+
+    def test_negation_selects_the_properties_without_coordinates(self) -> None:
+        found = PropertyRecord.objects.filter(~coordinates_exist(county="harris"))
+
+        self.assertEqual([p.account_number for p in found], ["WITHOUT"])
+
+    def test_negation_compiles_to_an_anti_join_not_a_not_in(self) -> None:
+        """The whole reason this is Exists and not account_number__in.
+
+        NOT IN cannot use a hash anti-join, and at production row counts that
+        difference was over an hour versus under a second. Assert on the
+        generated SQL so a well-meaning simplification back to __in gets caught.
+        """
+        sql = str(PropertyRecord.objects.filter(~coordinates_exist(county="harris")).query)
+
+        self.assertIn("NOT EXISTS", sql.upper())
+        self.assertNotIn("NOT IN", sql.upper())
+
+    def test_annotation_form_works_for_streaming_callers(self) -> None:
+        rows = PropertyRecord.objects.annotate(
+            has_coords=coordinates_exist(county="harris")
+        ).order_by("account_number")
+
+        self.assertEqual(
+            [(r.account_number, r.has_coords) for r in rows], [("WITH", True), ("WITHOUT", False)]
+        )

--- a/counties/harris/adapter.py
+++ b/counties/harris/adapter.py
@@ -23,6 +23,7 @@ from counties.common.contracts import (
     SearchField,
     Subject,
 )
+from counties.common.geometry import coordinates_for
 from counties.common.history import assessment_history_rows
 from counties.common.tax_impact import calculate_tax_impact
 from counties.harris.models import BuildingDetail, ExtraFeature, PropertyRecord
@@ -195,11 +196,7 @@ class HarrisAdapter(CountyAdapter):
         if prop.zipcode:
             locality = f"{locality} {prop.zipcode}".strip()
 
-        from counties.common.tax_models import ParcelGeometry
-
-        geom = ParcelGeometry.objects.filter(
-            account_number=prop.account_number, county="harris"
-        ).first()
+        location = coordinates_for(prop.account_number, county="harris")
 
         return Subject(
             key=prop.account_number,
@@ -215,7 +212,7 @@ class HarrisAdapter(CountyAdapter):
             year_built=building.year_built if building else None,
             quality_code=building.quality_code if building else None,
             features=format_feature_list(features),
-            has_location=bool(geom and geom.latitude and geom.longitude),
+            has_location=location is not None,
         )
 
     def find_comps(

--- a/counties/harris/etl_pipeline/readiness.py
+++ b/counties/harris/etl_pipeline/readiness.py
@@ -15,6 +15,7 @@ import logging
 from django.db import connection
 from django.db.models import Exists, OuterRef
 
+from counties.common.geometry import coordinates_exist
 from counties.harris.models import BuildingDetail, PropertyRecord
 
 logger = logging.getLogger(__name__)
@@ -105,17 +106,9 @@ def refresh_property_readiness() -> dict:
             cursor.execute(_SET_NEWLY_READY)
             results["ready_properties_changed"] = cursor.rowcount
     else:
-        from counties.common.tax_models import ParcelGeometry
-
-        accounts_with_coords = ParcelGeometry.objects.filter(
-            county="harris", latitude__isnull=False, longitude__isnull=False
-        ).values_list("account_number", flat=True)
-
         should_be_ready = (
-            PropertyRecord.objects.filter(
-                is_residential=True,
-                account_number__in=accounts_with_coords,
-            )
+            PropertyRecord.objects.filter(is_residential=True)
+            .filter(coordinates_exist(county="harris"))
             .annotate(has_ready_building=Exists(ready_buildings))
             .filter(has_ready_building=True)
         )

--- a/counties/harris/management/commands/check_and_import_data.py
+++ b/counties/harris/management/commands/check_and_import_data.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
-from counties.common.tax_models import ParcelGeometry
+from counties.common.geometry import coordinates_exist
 from counties.harris.models import BuildingDetail, PropertyRecord
 
 logger = logging.getLogger(__name__)
@@ -26,9 +26,7 @@ class Command(BaseCommand):
         # coverage exceed 100% and hide a genuinely missing GIS load.
         total_props = prop_count if prop_count > 0 else 1
         coords_count = PropertyRecord.objects.filter(
-            account_number__in=ParcelGeometry.objects.filter(
-                county="harris", latitude__isnull=False, longitude__isnull=False
-            ).values("account_number")
+            coordinates_exist(county="harris")
         ).count()
         coord_coverage = coords_count / total_props
 

--- a/counties/harris/management/commands/reconcile_property_data.py
+++ b/counties/harris/management/commands/reconcile_property_data.py
@@ -13,7 +13,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.db.models import Exists, OuterRef
 
-from counties.common.tax_models import ParcelGeometry
+from counties.common.geometry import coordinates_exist
 from counties.harris.etl import link_orphaned_records
 from counties.harris.etl_pipeline.readiness import refresh_property_readiness
 from counties.harris.models import BuildingDetail, ExtraFeature, PropertyRecord
@@ -168,21 +168,11 @@ class Command(BaseCommand):
             bathrooms__isnull=False,
         )
 
-        # Coordinates live in ParcelGeometry now, but they still have to be
-        # resolved per row *without* pulling the whole table into memory — this
-        # command streams with .iterator() precisely because PropertyRecord is
-        # ~1.2M rows, and a Python set of every account with coordinates would
-        # give that memory straight back.
-        has_geometry = ParcelGeometry.objects.filter(
-            account_number=OuterRef("account_number"),
-            county="harris",
-            latitude__isnull=False,
-            longitude__isnull=False,
-        )
-
+        # Resolved per row in SQL, not via a Python set: this command streams
+        # with .iterator() precisely because PropertyRecord runs to ~1.2M rows.
         queryset = PropertyRecord.objects.annotate(
             has_ready_building=Exists(ready_buildings),
-            has_coords=Exists(has_geometry),
+            has_coords=coordinates_exist(county="harris"),
         ).only("pk", "account_number", "state_class", "is_residential")
 
         results = {

--- a/counties/harris/management/commands/validate_data.py
+++ b/counties/harris/management/commands/validate_data.py
@@ -13,30 +13,10 @@ from __future__ import annotations
 import os
 
 from django.core.management.base import BaseCommand, CommandError
-from django.db.models import Count, Exists, OuterRef
+from django.db.models import Count
 
-from counties.common.tax_models import ParcelGeometry
+from counties.common.geometry import coordinates_exist
 from counties.harris.models import BuildingDetail, ExtraFeature, PropertyRecord
-
-
-def _harris_geometry_for_property():
-    """Correlated subquery: does this PropertyRecord have Harris coordinates?
-
-    Deliberately ``Exists`` rather than ``account_number__in=<queryset>``.
-    Django renders the ``__in`` form as ``IN (subquery)`` and its negation as
-    ``NOT IN (subquery)``, and ``NOT IN`` has to honour SQL's three-valued
-    logic — a single NULL in the subquery makes the whole predicate NULL — so
-    Postgres cannot use a hash anti-join and falls back to re-checking the
-    subquery per row. Against 1.17M properties x 1.55M parcels that took over
-    an hour without completing; ``NOT EXISTS`` plans as a hash anti-join and
-    returns in well under a second.
-    """
-    return ParcelGeometry.objects.filter(
-        account_number=OuterRef("account_number"),
-        county="harris",
-        latitude__isnull=False,
-        longitude__isnull=False,
-    )
 
 
 def _env_float(name: str, default: float) -> float:
@@ -143,7 +123,7 @@ class Command(BaseCommand):
             )
             residential_missing_gis = (
                 PropertyRecord.objects.filter(is_residential=True)
-                .filter(~Exists(_harris_geometry_for_property()))
+                .filter(~coordinates_exist(county="harris"))
                 .count()
             )
 
@@ -341,7 +321,7 @@ class Command(BaseCommand):
         elif residential_prop_count > 0:
             with_coords = (
                 PropertyRecord.objects.filter(is_residential=True)
-                .filter(Exists(_harris_geometry_for_property()))
+                .filter(coordinates_exist(county="harris"))
                 .count()
             )
             coord_pct = with_coords / residential_prop_count * 100

--- a/counties/harris/similarity.py
+++ b/counties/harris/similarity.py
@@ -504,17 +504,15 @@ def find_similar_properties(
     so the bounding-box filter and distance annotation run against that table,
     then the top candidates are joined back to PropertyRecord by account_number.
     """
+    from counties.common.geometry import coordinates_for
     from counties.common.tax_models import ParcelGeometry
 
-    # Get the target's coordinates from ParcelGeometry
-    target_geom = ParcelGeometry.objects.filter(
-        account_number=account_number, county="harris"
-    ).first()
-    if not target_geom or not target_geom.latitude or not target_geom.longitude:
+    location = coordinates_for(account_number, county="harris")
+    if location is None:
         return []
 
-    target_lat = float(target_geom.latitude)
-    target_lon = float(target_geom.longitude)
+    target_lat = float(location.latitude)
+    target_lon = float(location.longitude)
 
     # Get the target property record
     try:

--- a/counties/harris/similarity.py
+++ b/counties/harris/similarity.py
@@ -6,9 +6,6 @@ Uses location (lat/long), size, age, and features to find similar properties.
 from math import asin, cos, radians, sin, sqrt
 from typing import TYPE_CHECKING, Optional
 
-from django.db.models import ExpressionWrapper, F, FloatField, Value
-from django.db.models.functions import ACos, Cos, Greatest, Least, Radians, Sin
-
 from .models import BuildingDetail, ExtraFeature, PropertyRecord
 
 if TYPE_CHECKING:
@@ -16,11 +13,6 @@ if TYPE_CHECKING:
 
 
 QUALITY_RANK = {"X": 7, "A": 6, "B": 5, "C": 4, "D": 3, "E": 2, "F": 1}
-
-# How many nearest parcels find_similar_properties() pulls out of the database
-# to score in Python. Every one of these slots must buy a scoreable comp, which
-# is why the property-backed filter is applied before the cap, not after.
-MAX_GEOMETRY_CANDIDATES = 2000
 
 RESIDENTIAL_WEIGHTS = {
     "living_area": 24.0,
@@ -504,8 +496,7 @@ def find_similar_properties(
     so the bounding-box filter and distance annotation run against that table,
     then the top candidates are joined back to PropertyRecord by account_number.
     """
-    from counties.common.geometry import coordinates_for
-    from counties.common.tax_models import ParcelGeometry
+    from counties.common.geometry import coordinates_for, nearest_parcels
 
     location = coordinates_for(account_number, county="harris")
     if location is None:
@@ -526,96 +517,32 @@ def find_similar_properties(
     target_building = target.buildings.filter(is_active=True).first()  # type: ignore[attr-defined]
     target_features = list(target.extra_features.filter(is_active=True))  # type: ignore[attr-defined]
 
-    # Calculate bounding box for initial index-based filtering
-    # 1 degree lat =~ 69 miles
-    lat_range = max_distance_miles / 69.0
-    lon_range = max_distance_miles / (69.0 * cos(radians(target_lat)))
-
-    min_lat = target_lat - lat_range
-    max_lat = target_lat + lat_range
-    min_lon = target_lon - lon_range
-    max_lon = target_lon + lon_range
-
-    # 1. Base filter by bounding box on ParcelGeometry (uses lat/long index)
-    geom_candidates = ParcelGeometry.objects.filter(
-        county="harris",
-        latitude__gte=min_lat,
-        latitude__lte=max_lat,
-        longitude__gte=min_lon,
-        longitude__lte=max_lon,
-        latitude__isnull=False,
-        longitude__isnull=False,
-    ).exclude(account_number=account_number)
-
-    # 2. Restrict to parcels that actually have a property behind them.
-    #
-    # This has to happen before the cap at (4), not after. ParcelGeometry holds
-    # every parcel in HCAD's shapefile — commercial and vacant included —
-    # whereas PropertyRecord is residential-only, so a geometry row with no
-    # property would otherwise consume one of the 2000 candidate slots and then
-    # be dropped at the join below, silently shrinking the pool of real comps.
-    #
-    # The heat_area branch already provides this transitively: BuildingDetail
-    # rows are only written for accounts in the residential account map. Adding
-    # the PropertyRecord semi-join on top of it measured ~2x slower (265ms vs
-    # 128ms on 1.17M rows) because the planner stops driving from the bounding
-    # box, so the two are deliberately exclusive rather than stacked.
-    candidate_accts: list[str]
+    # Restrict candidates to parcels with a property behind them. When the
+    # subject has a living area we can be stricter and require a building in a
+    # comparable size range -- BuildingDetail rows only exist for accounts in
+    # the residential map, so that is property-backed too, and narrowing here
+    # rather than stacking both restrictions keeps the planner driving from the
+    # bounding box (measured 128ms against 265ms when both were applied).
     if target_building and target_building.heat_area:
-        min_area = float(target_building.heat_area) * 0.5
-        max_area = float(target_building.heat_area) * 1.5
-
-        matching_buildings = BuildingDetail.objects.filter(
-            is_active=True, heat_area__gte=min_area, heat_area__lte=max_area
+        backed_by = BuildingDetail.objects.filter(
+            is_active=True,
+            heat_area__gte=float(target_building.heat_area) * 0.5,
+            heat_area__lte=float(target_building.heat_area) * 1.5,
         ).values("account_number")
-
-        geom_candidates = geom_candidates.filter(account_number__in=matching_buildings)
     else:
-        geom_candidates = geom_candidates.filter(
-            account_number__in=PropertyRecord.objects.values("account_number")
-        )
+        backed_by = PropertyRecord.objects.values("account_number")
 
-    # 3. Annotate with distance calculation and filter
-    # Formula: 3959 * acos(cos(radians(lat1)) * cos(radians(lat2)) * cos(radians(long2) - radians(long1)) + sin(radians(lat1)) * sin(radians(lat2)))
-
-    target_lat_rad = radians(target_lat)
-    target_lon_rad = radians(target_lon)
-
-    geom_candidates = (
-        geom_candidates.annotate(
-            distance=ExpressionWrapper(
-                3959.0
-                * ACos(
-                    Least(
-                        1.0,
-                        Greatest(
-                            -1.0,
-                            Cos(Value(target_lat_rad))
-                            * Cos(Radians(F("latitude")))
-                            * Cos(Radians(F("longitude")) - Value(target_lon_rad))
-                            + Sin(Value(target_lat_rad)) * Sin(Radians(F("latitude"))),
-                        ),
-                    )
-                ),
-                output_field=FloatField(),
-            )
-        )
-        .filter(distance__lte=max_distance_miles)
-        .order_by("distance")
+    distance_map = nearest_parcels(
+        location,
+        county="harris",
+        within_miles=max_distance_miles,
+        backed_by=backed_by,
+        exclude_account=account_number,
     )
-
-    # 4. Cap the candidates we process in Python. Every row that survives to
-    # here is property-backed (see 2), so all the slots buy a real comp.
-    geom_candidates = geom_candidates[:MAX_GEOMETRY_CANDIDATES]
-
-    # Evaluate the geometry queryset to get account_numbers + distances
-    geom_list = list(geom_candidates.values("account_number", "distance"))
-
-    if not geom_list:
+    if not distance_map:
         return []
 
-    candidate_accts = [g["account_number"] for g in geom_list]
-    distance_map = {g["account_number"]: g["distance"] for g in geom_list}
+    candidate_accts = list(distance_map)
 
     # Bulk fetch the property records for these candidates
     candidate_list = list(PropertyRecord.objects.filter(account_number__in=candidate_accts))

--- a/counties/harris/tests/test_similarity_scoring.py
+++ b/counties/harris/tests/test_similarity_scoring.py
@@ -280,7 +280,7 @@ class GeometryCandidateCapTests(TestCase):
         self._property(self.COMP)
         self._geometry(self.COMP, longitude="-95.5001000")
 
-        with patch("counties.harris.similarity.MAX_GEOMETRY_CANDIDATES", 1):
+        with patch("counties.common.geometry.MAX_NEARBY_PARCELS", 1):
             results = find_similar_properties(self.TARGET, min_score=0.0)
 
         self.assertEqual([r["property"].account_number for r in results], [self.COMP])
@@ -314,7 +314,7 @@ class GeometryCandidateCapTests(TestCase):
             is_active=True,
         )
 
-        with patch("counties.harris.similarity.MAX_GEOMETRY_CANDIDATES", 1):
+        with patch("counties.common.geometry.MAX_NEARBY_PARCELS", 1):
             results = find_similar_properties(self.TARGET, min_score=0.0)
 
         self.assertEqual([r["property"].account_number for r in results], [self.COMP])


### PR DESCRIPTION
Two deep-module refactors, stacked on #27. No behaviour change — verified against the real 1.17M-property dataset.

## 1. `counties/common/geometry.py` — coordinate lookup gets an interface

**14 call sites** reached `ParcelGeometry.objects` directly, with **28 hardcoded county literals**. Each had to know the same facts: scope by county, `latitude`/`longitude` are independently nullable, rows are keyed by an account-number string rather than an FK, and the table holds every parcel in the shapefile rather than only ones with a property behind them.

Knowing those in fourteen places meant knowing them *inconsistently* — the adapters fetched a row and null-checked in Python while the bulk path filtered nulls in SQL. Same question, two encodings.

```python
coordinates_for(account_number, county=...) -> Coordinates | None
accounts_with_coordinates(account_numbers, county=...) -> set[str]
coordinates_exist(county=..., account_field=...) -> Exists
```

Two deliberate constraints:

- `accounts_with_coordinates` takes an **explicit account list** rather than offering to fetch a whole county. Materialising millions of rows into Python was a real bug in `reconcile_property_data`; this interface doesn't make it available.
- `coordinates_exist` is an `Exists`, never `__in`. The negated `__in` form renders as `NOT IN (subquery)`, which can't use a hash anti-join — that distinction cost **66 minutes of a stalled ETL**. A test asserts on the compiled SQL so a well-meaning simplification gets caught.

**Zero direct `ParcelGeometry` reads remain outside the module.**

## 2. `nearest_parcels()` — the seam both counties were missing

Harris and Brazos each carried the same ~40 lines: bounding box, haversine annotation, cap, unpacking — down to `MAX_GEOMETRY_CANDIDATES` defined in both files. The evidence wasn't structural but historical: **the cap-ordering bug had to be fixed twice, with two regression tests**, because the code existed twice.

```python
nearest_parcels(origin, county=..., within_miles=..., backed_by=...,
                exclude_account=...) -> {account_number: miles}
```

`backed_by` is **required**, and that's the design. Forgetting to restrict candidates to parcels with a record behind them is the exact bug that cost 37.6% of a search's candidate slots — a required argument makes that call impossible to write. What backs them is the real variation between counties (Harris: properties, or buildings in a size range; Brazos: accounts for the tax year), which is what the seam carries.

## One trap worth flagging

Extracting the cap left `MAX_GEOMETRY_CANDIDATES` **orphaned** in both county modules — still defined, no longer used — so all three cap regression tests were patching a dead name and passing vacuously. The seam's limit also resolved as a default argument, which binds at definition time and would have left a repointed patch inert.

Both fixed: the constant is gone, the limit resolves at call time, the tests patch `MAX_NEARBY_PARCELS`, and I confirmed all three **fail** when the restriction is removed.

## Verification

452 tests (440 + 12 new), ruff, mypy. On real data the same subject returns the same 50 comparables with the same top score of 81.7, in 0.88s.

| | before | after |
|---|---:|---:|
| `harris/similarity.py` | 721 | 648 |
| `brazos/similarity.py` | 670 | 620 |
| `common/geometry.py` | — | 205 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)