### PR TITLE
Honest load counts, a typed readiness result, and the missing research docs

### DIFF
--- a/counties/harris/etl_pipeline/model_loader.py
+++ b/counties/harris/etl_pipeline/model_loader.py
@@ -25,10 +25,22 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ModelLoadResult:
-    """Result of loading records into a Django model."""
+    """Result of loading records into a Django model.
+
+    ``records_loaded`` is rows that actually reached the table, measured as a
+    row-count delta rather than as "rows handed to bulk_create". Those are not
+    the same number: every loader passes ``ignore_conflicts=True``, so a row
+    whose key already exists is dropped silently. Counting what was offered
+    made ``records_loaded`` read like a completeness signal while overstating
+    it — on a real HCAD run, 905,338 offered against 871,769 persisted.
+
+    ``records_conflicted`` is that gap, which is worth surfacing rather than
+    hiding: it counts duplicate keys within the source file.
+    """
 
     model_name: str
     records_loaded: int = 0
+    records_conflicted: int = 0
     records_invalid: int = 0
     records_skipped: int = 0
     batch_id: str = ""
@@ -129,12 +141,18 @@ class ModelLoader:
 
         try:
             buf: list[BuildingDetail] = []
+            offered = 0
 
             # Truncate and reload run in ONE transaction so a mid-load failure
             # rolls the truncate back instead of leaving the table empty.
             with transaction.atomic():
                 if truncate:
                     self._truncate_table(BuildingDetail)
+
+                # Snapshot inside the transaction, after any truncate: what
+                # lands is measured as a delta, because bulk_create's
+                # ignore_conflicts silently drops duplicate keys.
+                rows_before = BuildingDetail.objects.count()
 
                 for item in rows:
                     if item.skip:
@@ -180,9 +198,9 @@ class ModelLoader:
 
                     if len(buf) >= self.batch_size:
                         BuildingDetail.objects.bulk_create(buf, ignore_conflicts=True)
-                        result.records_loaded += len(buf)
+                        offered += len(buf)
                         self.logger.info(
-                            f"Loaded {result.records_loaded} building records "
+                            f"Offered {offered} building records "
                             f"(invalid: {result.records_invalid}, skipped: {result.records_skipped})"
                         )
                         buf.clear()
@@ -190,9 +208,15 @@ class ModelLoader:
                 # Load remaining records
                 if buf:
                     BuildingDetail.objects.bulk_create(buf, ignore_conflicts=True)
-                    result.records_loaded += len(buf)
+                    offered += len(buf)
 
-            self.logger.info(f"Completed: Loaded {result.records_loaded} building detail records")
+                result.records_loaded = BuildingDetail.objects.count() - rows_before
+                result.records_conflicted = offered - result.records_loaded
+
+            self.logger.info(
+                f"Completed: Loaded {result.records_loaded} building detail records"
+                f" ({result.records_conflicted} dropped as duplicate keys)"
+            )
 
         except Exception as e:
             result.error = str(e)
@@ -221,12 +245,18 @@ class ModelLoader:
 
         try:
             buf: list[ExtraFeature] = []
+            offered = 0
 
             # Truncate and reload run in ONE transaction so a mid-load failure
             # rolls the truncate back instead of leaving the table empty.
             with transaction.atomic():
                 if truncate:
                     self._truncate_table(ExtraFeature)
+
+                # Snapshot inside the transaction, after any truncate: what
+                # lands is measured as a delta, because bulk_create's
+                # ignore_conflicts silently drops duplicate keys.
+                rows_before = ExtraFeature.objects.count()
 
                 for item in rows:
                     if item.skip:
@@ -261,9 +291,9 @@ class ModelLoader:
 
                     if len(buf) >= self.batch_size:
                         ExtraFeature.objects.bulk_create(buf, ignore_conflicts=True)
-                        result.records_loaded += len(buf)
+                        offered += len(buf)
                         self.logger.info(
-                            f"Loaded {result.records_loaded} extra feature records "
+                            f"Offered {offered} extra feature records "
                             f"(invalid: {result.records_invalid}, skipped: {result.records_skipped})"
                         )
                         buf.clear()
@@ -271,9 +301,15 @@ class ModelLoader:
                 # Load remaining records
                 if buf:
                     ExtraFeature.objects.bulk_create(buf, ignore_conflicts=True)
-                    result.records_loaded += len(buf)
+                    offered += len(buf)
 
-            self.logger.info(f"Completed: Loaded {result.records_loaded} extra feature records")
+                result.records_loaded = ExtraFeature.objects.count() - rows_before
+                result.records_conflicted = offered - result.records_loaded
+
+            self.logger.info(
+                f"Completed: Loaded {result.records_loaded} extra feature records"
+                f" ({result.records_conflicted} dropped as duplicate keys)"
+            )
 
         except Exception as e:
             result.error = str(e)
@@ -301,6 +337,7 @@ class ModelLoader:
 
         try:
             buf: list[PropertyRecord] = []
+            offered = 0
 
             # Truncate and reload run in ONE transaction so a mid-load failure
             # rolls the truncate back instead of leaving the table empty.
@@ -309,6 +346,11 @@ class ModelLoader:
                     self._truncate_table(PropertyRecord)
                     # Clear cached account data since we're truncating
                     self.reset_cache()
+
+                # Snapshot inside the transaction, after any truncate: what
+                # lands is measured as a delta, because bulk_create's
+                # ignore_conflicts silently drops duplicate keys.
+                rows_before = PropertyRecord.objects.count()
 
                 for item in rows:
                     if item.skip:
@@ -339,9 +381,9 @@ class ModelLoader:
 
                     if len(buf) >= self.batch_size:
                         PropertyRecord.objects.bulk_create(buf, ignore_conflicts=True)
-                        result.records_loaded += len(buf)
+                        offered += len(buf)
                         self.logger.info(
-                            f"Loaded {result.records_loaded} property records "
+                            f"Offered {offered} property records "
                             f"(skipped: {result.records_skipped})"
                         )
                         buf.clear()
@@ -349,9 +391,15 @@ class ModelLoader:
                 # Load remaining records
                 if buf:
                     PropertyRecord.objects.bulk_create(buf, ignore_conflicts=True)
-                    result.records_loaded += len(buf)
+                    offered += len(buf)
 
-            self.logger.info(f"Completed: Loaded {result.records_loaded} property records")
+                result.records_loaded = PropertyRecord.objects.count() - rows_before
+                result.records_conflicted = offered - result.records_loaded
+
+            self.logger.info(
+                f"Completed: Loaded {result.records_loaded} property records"
+                f" ({result.records_conflicted} dropped as duplicate keys)"
+            )
 
             # Clear cached data since we've modified the table
             self.reset_cache()

--- a/counties/harris/etl_pipeline/readiness.py
+++ b/counties/harris/etl_pipeline/readiness.py
@@ -11,6 +11,7 @@ calls it once after a successful load (see
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 from django.db import connection
 from django.db.models import Exists, OuterRef
@@ -79,7 +80,28 @@ WHERE data_propertyrecord.id = b.property_id
 """
 
 
-def refresh_property_readiness() -> dict:
+@dataclass(frozen=True)
+class ReadinessSummary:
+    """What a readiness refresh evaluated and what it changed.
+
+    A dataclass rather than a dict because these field names are a contract --
+    ``reconcile_property_data`` prints ``ready_properties_set`` to users -- and
+    a dict makes that contract discoverable only by reading the function body.
+
+    ``ready_properties_set`` is the *total* number of ready properties, not a
+    delta: it is the number callers report. ``ready_properties_changed`` and
+    ``ready_properties_cleared`` are the deltas, and on a steady-state re-run
+    both are zero while the total stays put.
+    """
+
+    properties_evaluated: int
+    residential_properties: int
+    ready_properties_set: int
+    ready_properties_changed: int
+    ready_properties_cleared: int
+
+
+def refresh_property_readiness() -> ReadinessSummary:
     """Recompute PropertyRecord.is_data_ready from building, room, and GIS completeness.
 
     Writes only the rows whose readiness actually changes. ``ready_properties_set``
@@ -94,17 +116,15 @@ def refresh_property_readiness() -> dict:
     )
 
     residential_properties = PropertyRecord.objects.filter(is_residential=True)
-    results = {
-        "properties_evaluated": PropertyRecord.objects.count(),
-        "residential_properties": residential_properties.count(),
-    }
+    properties_evaluated = PropertyRecord.objects.count()
+    residential_count = residential_properties.count()
 
     if connection.vendor == "postgresql":
         with connection.cursor() as cursor:
             cursor.execute(_CLEAR_NO_LONGER_READY)
-            results["ready_properties_cleared"] = cursor.rowcount
+            cleared = cursor.rowcount
             cursor.execute(_SET_NEWLY_READY)
-            results["ready_properties_changed"] = cursor.rowcount
+            changed = cursor.rowcount
     else:
         should_be_ready = (
             PropertyRecord.objects.filter(is_residential=True)
@@ -114,25 +134,31 @@ def refresh_property_readiness() -> dict:
         )
         ready_ids = list(should_be_ready.values_list("pk", flat=True))
 
-        results["ready_properties_changed"] = (
+        changed = (
             PropertyRecord.objects.filter(pk__in=ready_ids)
             .exclude(is_data_ready=True)
             .update(is_data_ready=True)
         )
-        results["ready_properties_cleared"] = (
+        cleared = (
             PropertyRecord.objects.filter(is_data_ready=True)
             .exclude(pk__in=ready_ids)
             .update(is_data_ready=False)
         )
 
-    results["ready_properties_set"] = PropertyRecord.objects.filter(is_data_ready=True).count()
+    summary = ReadinessSummary(
+        properties_evaluated=properties_evaluated,
+        residential_properties=residential_count,
+        ready_properties_set=PropertyRecord.objects.filter(is_data_ready=True).count(),
+        ready_properties_changed=changed,
+        ready_properties_cleared=cleared,
+    )
 
     logger.info(
         "Refreshed property readiness: %s/%s residential properties ready "
         "(%s newly ready, %s cleared)",
-        results["ready_properties_set"],
-        results["residential_properties"],
-        results["ready_properties_changed"],
-        results["ready_properties_cleared"],
+        summary.ready_properties_set,
+        summary.residential_properties,
+        summary.ready_properties_changed,
+        summary.ready_properties_cleared,
     )
-    return results
+    return summary

--- a/counties/harris/etl_pipeline/tests/test_integration.py
+++ b/counties/harris/etl_pipeline/tests/test_integration.py
@@ -248,6 +248,51 @@ class TestModelLoaderExtraFeatures(TestCase):
         assert feature.quality_code == ""
         assert feature.condition_code == ""
 
+    def test_records_loaded_counts_rows_that_landed_not_rows_offered(self):
+        """bulk_create(ignore_conflicts=True) drops duplicate keys silently.
+
+        Counting what was handed to bulk_create made records_loaded read like a
+        completeness signal while overstating it -- on a real HCAD run, 905,338
+        offered against 871,769 actually persisted. The gap is now reported as
+        records_conflicted rather than absorbed into the success count.
+        """
+        prop = PropertyRecord.objects.create(
+            address="3 MAIN ST",
+            city="Houston",
+            zipcode="77001",
+            account_number="ACC3",
+            state_class="A1",
+            is_residential=True,
+        )
+
+        def _row():
+            # Same (account_number, feature_code, feature_number) each time, so
+            # every row after the first collides with unique_feature_per_account.
+            return RowResult(
+                row=ExtraFeatureRow(
+                    property_id=prop.id,
+                    account_number="ACC3",
+                    feature_number=1,
+                    feature_code="RRP5",
+                    feature_description="Gunite Pool",
+                    quantity=None,
+                    length=None,
+                    width=None,
+                    quality_code="",
+                    condition_code="",
+                    year_built=None,
+                    value=None,
+                    is_active=True,
+                )
+            )
+
+        loader = ModelLoader(self.config, batch_size=10)
+        result = loader.load_extra_features(iter([_row(), _row(), _row()]), truncate=True)
+
+        assert ExtraFeature.objects.count() == 1
+        assert result.records_loaded == 1
+        assert result.records_conflicted == 2
+
 
 class TestETLOrchestratorIntegration(TestCase):
     """Integration tests for ETL orchestrator."""

--- a/counties/harris/etl_pipeline/tests/test_ported_from_legacy.py
+++ b/counties/harris/etl_pipeline/tests/test_ported_from_legacy.py
@@ -113,7 +113,7 @@ class RefreshPropertyReadinessTests(TestCase):
         missing_gis_prop.refresh_from_db()
         non_residential.refresh_from_db()
 
-        self.assertEqual(results["ready_properties_set"], 1)
+        self.assertEqual(results.ready_properties_set, 1)
         self.assertTrue(ready_prop.is_data_ready)
         self.assertFalse(missing_gis_prop.is_data_ready)
         self.assertFalse(non_residential.is_data_ready)
@@ -131,14 +131,14 @@ class RefreshPropertyReadinessTests(TestCase):
         self._create_property(account_number="WAIT001", with_gis=False)
 
         first = refresh_property_readiness()
-        self.assertEqual(first["ready_properties_changed"], 1)
-        self.assertEqual(first["ready_properties_set"], 1)
+        self.assertEqual(first.ready_properties_changed, 1)
+        self.assertEqual(first.ready_properties_set, 1)
 
         second = refresh_property_readiness()
-        self.assertEqual(second["ready_properties_changed"], 0)
-        self.assertEqual(second["ready_properties_cleared"], 0)
+        self.assertEqual(second.ready_properties_changed, 0)
+        self.assertEqual(second.ready_properties_cleared, 0)
         # ...and the answer is unchanged, not merely unwritten.
-        self.assertEqual(second["ready_properties_set"], 1)
+        self.assertEqual(second.ready_properties_set, 1)
         ready_prop.refresh_from_db()
         self.assertTrue(ready_prop.is_data_ready)
 
@@ -156,8 +156,8 @@ class RefreshPropertyReadinessTests(TestCase):
 
         results = refresh_property_readiness()
 
-        self.assertEqual(results["ready_properties_cleared"], 1)
-        self.assertEqual(results["ready_properties_set"], 0)
+        self.assertEqual(results.ready_properties_cleared, 1)
+        self.assertEqual(results.ready_properties_set, 0)
         ready_prop.refresh_from_db()
         self.assertFalse(ready_prop.is_data_ready)
 

--- a/counties/harris/management/commands/check_and_import_data.py
+++ b/counties/harris/management/commands/check_and_import_data.py
@@ -25,9 +25,7 @@ class Command(BaseCommand):
         # PropertyRecord never holds, so counting the table directly would let
         # coverage exceed 100% and hide a genuinely missing GIS load.
         total_props = prop_count if prop_count > 0 else 1
-        coords_count = PropertyRecord.objects.filter(
-            coordinates_exist(county="harris")
-        ).count()
+        coords_count = PropertyRecord.objects.filter(coordinates_exist(county="harris")).count()
         coord_coverage = coords_count / total_props
 
         missing_data = []

--- a/counties/harris/management/commands/reconcile_property_data.py
+++ b/counties/harris/management/commands/reconcile_property_data.py
@@ -135,7 +135,7 @@ class Command(BaseCommand):
             f"  Features relinked:                 {link_results['features_linked']:>10,}"
         )
         self.stdout.write(
-            f"  Ready properties recomputed:       {readiness_results['ready_properties_set']:>10,}"
+            f"  Ready properties recomputed:       {readiness_results.ready_properties_set:>10,}"
         )
         self.stdout.write(
             f"  Properties deleted:                {deletion_totals.get('data.PropertyRecord', 0):>10,}"

--- a/docs/research/brazos-building-characteristics.md
+++ b/docs/research/brazos-building-characteristics.md
@@ -1,0 +1,68 @@
+# Brazos building characteristics (bed/bath/quality/condition/sqft)
+
+Research for [wayfinder ticket #6](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/4) on the [Brazos County tax-analysis parity map](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/3).
+
+## Question
+
+Does BCAD publish structured building characteristics anywhere — bedroom count, bathroom count, a quality code, a condition code, living-area square footage — the fields Harris's similarity scoring is actually weighted on (living area 24%, bedrooms 14%, bathrooms 12%, quality 10%, age 8%, condition 6%, stories 4%, building character 4%; see `CLAUDE.md`'s Similarity Algorithm section)?
+
+## Finding: yes — already in hand, no external search needed
+
+**Source**: `var/bcad_extracted/2025/2025-07-23_002022_APPRAISAL_IMPROVEMENT_DETAIL_ATTR.TXT` (real 2025 BCAD certified export, already downloaded; 394,291 rows, uniform 87-char fixed-width lines).
+
+This file encodes building characteristics as attribute-type/attribute-value pairs, one row per (improvement detail, attribute):
+
+| Field | Offset | Notes |
+|---|---|---|
+| `prop_id` | 0:12 | verified against known real prop_ids |
+| `tax_year` | 12:16 | |
+| `imp_id` | 16:28 | verified matches a real known `imp_id` for prop `000000010008` (the same test property used throughout the original 5-file decode) |
+| (unlabeled linking field) | 28:40 | detail_seq-style, not further decoded in this pass |
+| (unlabeled linking field) | 40:52 | not further decoded in this pass |
+| `attribute_type` | 52:77 | 25-char, space-padded |
+| `attribute_value` | 77:87 | 10-char |
+
+### Attribute-type vocabulary (16 distinct types found)
+
+| Attribute | Row count | Sample values | Use |
+|---|---|---|---|
+| Plumbing | 43,495 | `2`, `3`, `1`, `2/1`, `4`, `3/1`, `1/1`, `2.5`, `4.5` | **Bathroom count** — `X/Y` = X full + Y half baths, or `X.5` = X full + 1 half |
+| Number of Bedrooms | 43,116 | integers 1–12 | **Bedroom count** — directly usable |
+| Number of Rooms | 14,832 | integers 1–15 | Total room count |
+| Exterior Wall | 38,476 | BV, FR, HS, MT, ST, BK, ... | Material code |
+| Foundation | 37,727 | CS, CB, BK, WP | Material code |
+| Roof Covering | 36,512 | CP, HP, GA, MT, BU | Material code |
+| Heating/Cooling | 35,867 | AH, WU, NO, SP, CA, CH | System code |
+| Fireplace | 32,613 | (feature flag, not sampled in detail) | |
+| Interior Finish | 30,949 | SR, IN, PR, UN, SW, PN | Finish code |
+| Construction Style | 30,822 | FR, SF, CB, SS, TU, RC | Style code |
+| Other Feature | 26,160 | free text, e.g. "STORAGE BUILDING" | |
+| Flooring | 12,375 | CP, TL, CN, WD, CT (sometimes combined, e.g. "CP, TL") | |
+| Covered Patio/Deck, Carport, O/D Kitchen, Pool Attributes, Built-ins | 70–6,605 each | | Feature-presence rows |
+
+**Condition-style rating confirmed to exist in the PACS vocabulary**: `Carport`'s values are `F` (Fair) / `A` (Avg) / `G` (Good) — a Fair/Average/Good scale. No single overall building-wide quality/condition code (matching Harris's X/A/B/C/D grade) was found in this file specifically, but this confirms the PACS system uses this style of rating somewhere in its schema. Worth checking whether it applies more broadly — e.g. inside `APPRAISAL_IMPROVEMENT_INFO.TXT`'s still-ambiguous decimal fields at offsets 69:83/83:98 (flagged as "unclear semantics" during the original decode) — as a natural follow-up, not a blocker to using what's already confirmed.
+
+**Not found in this file**: square footage. Living-area sqft most likely already lives in the already-ingested `APPRAISAL_IMPROVEMENT_DETAIL.TXT`'s `detail_quantity` field for "MAIN AREA"-type component rows (values like `1800.000000` were seen during the original 5-file decode) — this is arguably already captured under `PropertyImprovementDetail`, just not yet aggregated per-improvement into a single square-footage figure.
+
+### Update: sqft, year built, and a class code also confirmed via the GIS parcel shapefile
+
+The sibling research on [wayfinder ticket #4](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/4) (true situs address) downloaded and inspected BCAD's GIS parcel shapefile (`brazoscad.org/tax-information/gis/`, 2025: `BrazosCADParcels_20260422.zip`) and found it also carries, as clean typed attribute fields:
+
+- `living_are` — living area sqft (e.g. `1608`)
+- `yr_blt` — year built (e.g. `1991`)
+- `class_cd` — a class/quality-style code (e.g. `RF1`, `RF2P`) — likely a quality/class proxy, exact format/meaning not yet confirmed
+
+This fills the one gap left by `APPRAISAL_IMPROVEMENT_DETAIL_ATTR.TXT` above. Combined, Brazos now has a plausible source for nearly everything Harris's similarity weighting needs: living area ✓ (shapefile), bedrooms ✓ (attr file), bathrooms ✓ (attr file), quality ~ (shapefile `class_cd`, format TBD), age ✓ (shapefile `yr_blt`), condition ~ (Fair/Avg/Good vocabulary exists via `Carport`, not yet confirmed as a whole-building rating), building character ✓ (attr file construction/material codes), extra features ✓ (attr file pool/patio/etc). Stories is the one dimension neither source has confirmed yet.
+
+See [wayfinder ticket #7](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/7) (dedicated GIS shapefile characterization) for the authoritative full field list, CRS, and join-key details once it resolves.
+
+## Bottom line
+
+Real, structured, comps-ready data exists today in already-downloaded data. Bedroom count and bathroom count are clean and ready to ingest immediately. Room count and the six construction/material codes (exterior wall, foundation, roof, heating, interior finish, construction style) are usable as building-character signals. A Fair/Average/Good condition scale exists in the vocabulary (via `Carport`) and may generalize further. The GIS parcel shapefile independently confirms living area, year built, and a class code. This did not require checking BCAD's website or considering a public-records request — the primary-source answer from data already on disk (plus one already-public shapefile download) is conclusive.
+
+## Follow-up not covered by this ticket
+
+- Decode the two unlabeled linking fields at offset 28:40/40:52.
+- Confirm whether the Fair/Average/Good condition scale generalizes to a whole-building condition/quality rating, possibly via `APPRAISAL_IMPROVEMENT_INFO.TXT`'s offset 69:83/83:98 fields, or via the shapefile's `class_cd`.
+- Locate a "stories" field — not confirmed in either source yet.
+- Design how these attribute rows (one improvement can have many attribute rows of different types) and the shapefile's fields get modeled/ingested into `brazos_cad` — no model or ingest code changes were made as part of this research ticket.

--- a/docs/research/brazos-entity-tax-rates.md
+++ b/docs/research/brazos-entity-tax-rates.md
@@ -1,0 +1,40 @@
+# Brazos taxing-entity adopted tax rates
+
+Research for [wayfinder ticket #8](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/8) on the [Brazos County tax-analysis parity map](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/3).
+
+## Question
+
+Where does Brazos County publish adopted tax rates per taxing entity — mirroring how Harris sources data for `import_tax_unit_rates`?
+
+## Finding: not in the certified export — found externally, and simpler than Harris's own source
+
+### Not in the certified export
+
+Re-examined both entity-related files in `var/bcad_extracted/2025/`:
+
+- `APPRAISAL_ENTITY_TOTALS.TXT` (43 rows, 2140 chars/line) — per-entity certified value/exemption totals (a Truth-in-Taxation rollup), not rates. Confirmed via `entity_id` (0:12) / `entity_code` (12:17) / `entity_name` prefix followed by a long sequence of 15-digit zero-padded dollar totals (2 implied decimals). No field in the 0.4–2.0 decimal range consistent with a tax rate.
+- `APPRAISAL_ENTITY_INFO.TXT` (755,602 rows, 2750 chars/line) — a per-property × per-entity value/exemption breakdown (the Harris `PropertyJurisdictionExemption` equivalent). Same pattern — dense value totals and exemption-count flags, no rate field.
+
+Both are the certified-values-to-entities step of Truth-in-Taxation, which precedes rate adoption — rates get set later by each entity's own budget process, so structurally they wouldn't be in BCAD's property data export at all.
+
+### Found externally — BCAD itself publishes it, not the county tax assessor-collector
+
+**URL**: `https://brazoscad.org/tax-information/adopted-tax-rates/`
+**Format**: plain HTML table — columns Entity Code | Entity Name | M&O | I&S | Total Rate.
+
+Real 2025 example rows (entity codes match `APPRAISAL_ENTITY.TXT`'s `entity_code` field exactly — clean join key):
+
+| Entity Code | Entity Name | M&O | I&S | Total Rate |
+|---|---|---|---|---|
+| G1 | Brazos County | $0.389454 | $0.030246 | $0.419700 |
+| S1 | Bryan ISD | $0.676900 | $0.270000 | $0.946900 |
+| S2 | College Station ISD | $0.696300 | $0.279000 | $0.975300 |
+| C1 | City of Bryan | $0.452846 | $0.171154 | $0.624000 |
+
+15 entities total listed. `Total Rate = M&O + I&S`, spot-checked and sums correctly on every row.
+
+## Recommendation
+
+This is a lower-effort source than Harris's `import_tax_unit_rates` TSV-upload pattern — it's a static, scrapable HTML table on a page BCAD already controls, likely simpler to build a loader for (scrape → parse table → join on `entity_code`) than a file-upload workflow. Per the map's Notes, this ticket is lower priority than the others — tax impact calculations can degrade gracefully (`completeness="missing"`, the existing pattern in `data/tax_impact.py`) until this is implemented.
+
+`APPRAISAL_ENTITY.TXT` decoding itself was not touched here — it's already resolved elsewhere (see the original 5-file decode); this ticket was locate-only, no ingestion command was designed or built.

--- a/docs/research/brazos-exemptions.md
+++ b/docs/research/brazos-exemptions.md
@@ -1,0 +1,182 @@
+# Brazos property-tax exemption data source
+
+Research for [wayfinder ticket #10](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/10) on the [Brazos County tax-analysis parity map](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/3).
+
+## Question
+
+Where does Brazos County publish/export per-account jurisdiction exemption data — the equivalent of what Harris sources via `import_jur_exemptions` into `PropertyJurisdictionExemption`?
+
+## Finding: present in the certified export, in two files already downloaded — one already partially parsed
+
+Unlike the situs-address, value, and tax-rate questions (#4, #5, #8), exemption data is **not** a dead end for the bulk export. It's split across two files, both already sitting in `var/bcad_extracted/2025/`:
+
+- `APPRAISAL_INFO.TXT` — per-property T/F exemption-type flags. Already the source file for `pacs.py`'s `INFO_LAYOUT`, but the flags themselves aren't decoded yet.
+- `APPRAISAL_ENTITY_INFO.TXT` — per-property-per-taxing-entity exemption **dollar amounts** by type, plus the freeze-exemption type code. Not parsed at all today (previously examined only for tax-rate fields in the #8 research and correctly found to lack one — that pass didn't dig into the exemption columns, which is what this ticket adds).
+
+### The missing piece: an official field-layout spec exists and resolves both
+
+BCAD's `certified-data-downloads` page (`https://brazoscad.org/certified-data-downloads/`) publishes, alongside the yearly export ZIPs, a **"File Layout Reference"** PDF: `https://brazoscad.org/wp-content/uploads/2021/07/Appraisal-Export-Layout-8.0.25-2.pdf` ("Appraisal Transfer File Layout", True Automation / PACS, version date 03/24/2021). This is a byte-offset field dictionary for **all 17** `APPRAISAL_*.TXT` files, not just the 5 already reverse-engineered by this project. It is the primary source for everything below; every offset was then independently verified against the real 2025 export bytes (see next sections).
+
+### File #2 — `APPRAISAL_INFO.TXT`: per-property exemption flags
+
+Per the spec, this file (already `pacs.py`'s `INFO_LAYOUT` source, 9,247 chars/line) carries a block of `char(1)` `'T'`/`'F'` flags starting at byte offset 2609 (1-indexed):
+
+| Field | Offset | Meaning |
+|---|---|---|
+| `ha_exempt` | 2609 | Homestead |
+| `ov65_exempt` | 2610 | Over-65 |
+| `ov65s_exempt` | ~~2660~~ **2661** [CORRECTED — see Verification (issue #11)] | Over-65 surviving spouse |
+| `dp_exempt` | ~~2661~~ **2662** [CORRECTED — see Verification (issue #11)] | Disabled person |
+| `dv1_exempt`…`dv4s_exempt` | ~~2662–2670~~ **2663–2670** [CORRECTED — see Verification (issue #11)] | Disabled veteran, 8 flags = 4 rating tiers (10–30% / 30–50% / 50–70% / 70–100%) × self/surviving-spouse |
+| `ex_exempt` | 2671 | Total (100%) exemption |
+| `ab_exempt`, `en_exempt`, `fr_exempt`, `ht_exempt`, `pro_exempt`, `pc_exempt`, `so_exempt`, `ex366_exempt`, `ch_exempt` | 2723–2731 | Abatement / energy / freeport / historical / prorated / pollution-control / solar / <$500-minimum / charitable — **offset-to-name mapping unverified, see Verification (issue #11)** |
+
+Verified against the real file: sampled the first 149,225 lines of `/home/specter/dev/TaxProtest-Django/var/bcad_extracted/2025/2025-07-23_002022_APPRAISAL_INFO.TXT` at these byte offsets — all four spot-checked fields (`ha_exempt`, `ov65_exempt`, `dp_exempt`, `ex_exempt`) return only `'T'`/`'F'`, with plausible population rates (23.4% homestead, 9.2% over-65, 0.01% disabled-person, 0.006% total-exemption). No garbage/off-by-one noise, i.e. the offsets line up.
+
+> **Correction (issue #11):** the "0.01% disabled-person" rate quoted above was actually measured at offset 2661, which the deeper verification pass proved is `ov65s_exempt` (over-65 surviving spouse, correctly rare at 0.01%), not `dp_exempt`. The real `dp_exempt` is one byte over at offset 2662, with a more demographically plausible population rate of 0.30% (442/149,225). See the Verification section for the full evidence trail.
+
+These flags tell you *which* exemptions apply to a property, but carry no dollar amount — the amount is entity-specific (a $140,000 homestead exemption from an ISD is a different number than a county's), which is why it lives in File #3 instead.
+
+### File #3 — `APPRAISAL_ENTITY_INFO.TXT`: per-entity exemption amounts (the real analog of `PropertyJurisdictionExemption`)
+
+This is the 2.08 GB file at `/home/specter/dev/TaxProtest-Django/var/bcad_extracted/2025/2025-07-23_002022_APPRAISAL_ENTITY_INFO.TXT` (2,750 chars/line, no header, no delimiter — fixed-width like every other PACS file here). Per the spec it's short-named `PROP_ENT.TXT`, keyed on `prop_id` + `prop_val_yr` + `entity_id`, i.e. one row per property × taxing entity × year — structurally exactly what `PropertyJurisdictionExemption` wants, just wide (one column per exemption type) instead of long (one row per exemption type).
+
+Relevant fields per the spec (1-indexed byte offsets):
+
+| Field | Offset | Meaning |
+|---|---|---|
+| `prop_id` | 1–12 | Property ID |
+| `prop_val_yr` | 13–17 | Tax year |
+| `entity_id` | 42–53 | Internal entity ID |
+| `entity_cd` | 54–63 | Entity code (joins to `APPRAISAL_ENTITY.TXT`'s `entity_code`, already used for tax rates in #8) |
+| `entity_name` | 64–113 | Entity name |
+| `assessed_val` | 149–163 | Assessed value for this entity |
+| `taxable_val` | 164–178 | Taxable value for this entity (post-exemption) |
+| `hs_amt`, `ov65_amt`, `dp_amt`, `dv_amt`, `ex_amt`, `ch_amt`, `ab_amt`, `en_amt`, `fr_amt`, `ht_amt`, `pro_amt`, `pc_amt`, `so_amt`, `ex366_amt`, `lve_amt`, `eco_amt`, `chodo_amt`, `lh_amt`, `dvhs_amt`, `dvhss_amt`, `clt_amt`, `dvch_amt`, `dvchs_amt`, `masss_amt`, `frss_amt`, `abmno_amt`, `dstr_amt`, `dstrs_amt` | 299–2614 (scattered) | Dollar amount of each exemption type granted **by this entity** |
+| `freeze_exempt_type_cd` | 1615–1619 | Which exemption triggered this entity's tax ceiling/freeze (school over-65/disabled freeze), e.g. `'OV65'`, `'DP'` |
+| `freeze_transfer_exempt_type_cd` | 1620–1624 | Same, for a transferred freeze |
+
+Byte-level verification, done against a real, exempt row (`prop_id 000000010013`, `entity_cd G1` = Brazos County, tax year 2025):
+
+```
+prop_id                        [1:12]   = '000000010013'
+prop_val_yr                    [13:17]  = '02025'
+entity_id                      [42:53]  = '000000237993'
+entity_cd                      [54:63]  = 'G1        '
+entity_name                    [64:113] = 'BRAZOS COUNTY'
+assessed_val                   [149:163] = '000000000242613'  -> $242,613
+taxable_val                    [164:178] = '000000000167613'  -> $167,613
+hs_amt                         [299:313] = '000000000000000'  -> $0
+ov65_amt                       [314:328] = '000000000075000'  -> $75,000
+dp_amt                         [329:343] = '000000000000000'  -> $0
+dv_amt                         [344:358] = '000000000000000'  -> $0
+freeze_exempt_type_cd          [1615:1619] = 'OV65 '
+```
+
+`assessed_val - taxable_val` = `$242,613 - $167,613` = `$75,000`, exactly equal to `ov65_amt`. And BCAD's own published local-exemption reference (see below) states Brazos County's optional over-65 homestead exemption is **exactly $75,000** — an exact match against an independent source, not just internal arithmetic consistency.
+
+Note on decimal scaling: unlike the money fields in the 5 already-decoded files (`_money` in `pacs.py`, 2 implied decimal places), these `*_amt`/`assessed_val`/`taxable_val` fields appear to be **plain, unscaled dollar integers** — `'000000000075000'` reads as `$75,000`, not `$750.00`. This is inferred from the exact match to the published $75,000 rate, not from the spec (which just says `numeric(15)` with no scaling note). Confirm this convention against several more rows — ideally a non-round-number one — before writing a parser.
+
+Also sampled the `freeze_exempt_type_cd` field independently across 755,602 rows (before finding the spec) and found only a small, plausible vocabulary: `OV65` (31,416), `OV65 OV65` (2,955 — likely joint owners both over 65), `DP` (1,103), `OV65S` (51), `DP   DP` (40), `DPS` (7). Consistent with the spec's documented use as an exemption-type code.
+
+### Version drift, flagged but not resolved
+
+The spec PDF's own revision history ends in 2006 and its File #3 field table runs to byte 2614 (`dstrs_allocation_factor`), but the real 2025 export's lines are 2,750 chars — about 136 bytes longer than the documented layout accounts for. All offsets checked above lined up exactly regardless, but this means the spec may be missing fields added after 2021 (True Automation's disaster-exemption fields, marked in red as "recently added," suggest the format is still evolving) — do not assume the tail of the record is fully covered by this document without checking against additional real rows.
+
+### BCAD website corroboration
+
+- **`https://brazoscad.org/certified-data-downloads/`** — hosts the certified export ZIPs *and* the file-layout PDF above. Also linked from here: **`https://brazoscad.org/wp-content/uploads/2025/12/Exemption-amounts-2025.pdf`** ("Local Exemptions 2025") — a *reference table*, not per-account data: statutory/local-option exemption dollar amounts by taxing unit (Residential Homestead / Over-65 Homestead / Disabled Persons, split Required vs. Optional) plus a disabled-veteran disability-rating → exemption-amount table. This is what confirmed the $75,000 Brazos County figure above. Useful as a cross-check / fallback default table, not as an ingest source (no account numbers anywhere in it).
+- **`https://brazoscad.org/tax-information/gis/`** — GIS parcel shapefile, already the primary source for values/situs/building characteristics per #4–#7; not re-checked for exemptions here since the certified export already answers the question more precisely (per-account, per-entity, per-exemption-type dollar amounts — richer than anything a shapefile attribute table would carry).
+
+### Notable side-finding
+
+The `Appraisal-Export-Layout-8.0.25-2.pdf` found here is a general field dictionary for **all 17** `APPRAISAL_*.TXT` files (headers, property, entity association, entity totals, abstract/subdivision, state codes, improvements, land, agent, ARB, lawsuits, entity lookup, UDI conversion, country codes, arbitration, mobile homes, tax deferral) — not just the two used for this ticket. Worth keeping in mind for any future Brazos wayfinder ticket that needs to decode one of the still-unexamined files; it removes the guesswork the 5-already-decoded-files methodology in `pacs.py`'s docstring otherwise required.
+
+## Recommendation
+
+Data model mapping to `PropertyJurisdictionExemption`:
+
+- `account_number` ← `prop_id`
+- `tax_year` ← `prop_val_yr`
+- `tax_unit_code` ← `entity_cd` (File #3) — already the join key used for `TaxUnitRate` via the adopted-rates scrape (#8)
+- `exemption_code` / `exemption_amount` ← unpivot File #3's wide `*_amt` columns into one row per non-zero column (`hs_amt` → code `HS`, `ov65_amt` → code `OV65`, `dp_amt` → code `DP`, `dv_amt` → code `DV`, etc.)
+- `assessed_value` / `taxable_value` ← `assessed_val` / `taxable_val` (File #3, already per-entity, no derivation needed)
+- The File #2 T/F flags (`ha_exempt`, `ov65_exempt`, …) are redundant with File #3's non-zero `*_amt` columns for "does this exemption apply" — File #3 alone is likely sufficient for ingestion; File #2's flags are a useful cheap validation cross-check (flag `T` should imply a non-zero corresponding `*_amt` row exists in File #3) rather than a separate ingest source.
+
+Before writing an ingest command: (1) confirm the no-decimal-scaling interpretation of File #3's money fields against several more real rows, ideally non-round-number ones; (2) re-derive the field offsets from real bytes rather than trusting the spec verbatim past ~byte 2614, given the documented drift; (3) decide the exemption-code vocabulary to standardize on (the spec's field-name suffixes — `HS`, `OV65`, `OV65S`, `DP`, `DPS`, `DV1`–`DV4` + `S` variants, `EX`, `AB`, `EN`, `FR`, `HT`, `PRO`, `PC`, `SO`, `EX366`, `CH`, `LVE`, `ECO`, `CHODO`, `LH`, `DVHS`, `DVHSS`, `CLT`, `DVCH`, `DVCHS`, `MASSS`, `FRSS`, `ABMNO`, `DSTR`, `DSTRS` — is a superset of Harris's exemption codes and should probably be used as-is for `exemption_code`). This ticket is locate-only, per the usual convention (#4–#8) — no ingestion command was built here.
+
+## Verification (issue #11)
+
+The prior pass above checked exactly one field (`ov65_amt`) on one row. This pass samples several real properties across different exemption shapes and cross-references every claimed offset against internally-consistent real data (the `APPRAISAL_INFO.TXT` flags, `APPRAISAL_ENTITY_INFO.TXT`'s dollar amounts, and `freeze_exempt_type_cd`, which are three independently-populated fields that must agree if the offsets are right). It also attempted a live cross-check against BCAD's own public property-search site.
+
+### Methodology
+
+Wrote small ad-hoc Python scripts (not committed — one-off scans, discarded after use) against the real, already-downloaded 2025 export at `var/bcad_extracted/2025/`:
+
+- `2025-07-23_002022_APPRAISAL_INFO.TXT` — 149,225 lines, 9,247 content chars/line + CRLF (confirmed by measuring raw byte length of the first two lines: 9,249 bytes each, minus 2 for `\r\n`).
+- `2025-07-23_002022_APPRAISAL_ENTITY_INFO.TXT` — 755,602 lines, 2,750 content chars/line + CRLF (measured the same way: 2,752 bytes/line).
+
+Both files were read in **binary mode** and sliced by raw byte offset (not text-mode `open()`, which would risk universal-newline/encoding surprises) — `chr(byte)` for single-char flags, `.decode('latin-1')` for multi-byte fields, matching the ASCII-only content actually observed.
+
+Steps: (1) frequency-scanned every byte position in the `APPRAISAL_INFO.TXT` flag region (2600–2745) across all 149,225 lines to see which offsets ever contain `'T'` vs. which are constant space (a cheap, file-wide way to distinguish real flag bytes from padding, independent of the spec); (2) picked `prop_id`s showing different flag shapes (homestead-only, over-65+homestead, disabled-person, disabled-veteran tiers, total-exemption) and dumped their raw byte windows; (3) looked up the same `prop_id`s in `APPRAISAL_ENTITY_INFO.TXT` and checked whether `assessed_val − taxable_val` equals the sum of that entity's `*_amt` fields, and whether `freeze_exempt_type_cd` (a plain-text code like `'OV65'`, `'DP'`, `'OV65S'`, `'DPS'`) agrees with which `*_amt` field is non-zero — this is the cross-check that caught the offset error below, since a flag claiming "disabled person" next to entity rows that actually say `freeze_exempt_type_cd = 'OV65S'` is a direct contradiction, not a matter of interpretation.
+
+### Sample accounts checked
+
+| `prop_id` | `APPRAISAL_INFO.TXT` flags observed (corrected offsets) | `APPRAISAL_ENTITY_INFO.TXT` cross-check | Verdict |
+|---|---|---|---|
+| `000000010013` | ha=T, ov65=T | G1 (Brazos County): `ov65_amt`=$75,000, `assessed−taxable`=$75,000, `freeze='OV65 '`. S1 (Bryan ISD): `hs_amt`=$100,000, `ov65_amt`=$2,946 (non-round), sum=$102,946=`assessed−taxable` exactly. | Match — also the doc's original spot-check row |
+| `000000010055` | ha=T only | S1: `hs_amt`=$100,000, `assessed−taxable`=$100,000, no `ov65_amt`/`dp_amt`. G1: no exemption at all (county grants no local homestead here). | Match |
+| `000000010179`, `000000010209`, `000000010335` | ha=T, ov65=T, one DV-tier flag each (2663, 2670, 2665 respectively) | G1: `ov65_amt`=$75,000, `freeze='OV65 '`, plus `dv_amt`=$12,000 on every entity row (CAD/F2/G1/S1/ZRFND alike — a DV exemption applies district-wide, not per-taxing-unit like HS/OV65). | Match |
+| `000000010097` | ha=T, ov65=T, DV-tier flag at 2669 | `taxable_val` = **$0** on every entity (CAD/F4/G1/S1/ZRFND), but `dv_amt`=$0 too — the full value is exempted through some other, unsampled column, not the `dv_amt` offset this doc tracks. | Partial — see "dv_amt" caveat below |
+| `000000014115`, `000000016359`, `000000019107`, `000000027133`, `000000027474` | ha=T, flag at (corrected) 2661=T, all else in the block F | Every one of these: `freeze_exempt_type_cd = 'OV65S'` and non-zero `ov65_amt` (not `dp_amt`) on G1/S1. `000000027133` G1: `ov65_amt`=$26,935 (non-round) + `dv_amt`=$12,000 = $38,935 = `assessed−taxable` exactly. | Confirms offset 2661 is `ov65s_exempt`, **not** `dp_exempt` as originally documented |
+| `000000010791`, `000000010803`, `000000011073`, `000000012421`, `000000012599` | ha=T, flag at (corrected) 2662=T | `freeze_exempt_type_cd = 'DP'` (or `'DPS'` for 010791) and `dp_amt`=$10,000 on S1 (Bryan ISD) for every one of these. | Confirms offset 2662 is the real `dp_exempt` |
+| `000000367255`, `000000367313`, `000000367516` | ex=T (2671) only, no other flags in the block | `taxable_val` = $0 on every entity for `000000367255` (checked: CAD/City/G1/ISD/ZRFND all zero), consistent with a total exemption. | Match |
+
+### Offset corrections (APPRAISAL_INFO.TXT)
+
+The flag block from `ov65s_exempt` through the disabled-veteran tiers is shifted **one byte later** than originally documented; `ha_exempt` (2609), `ov65_exempt` (2610), and `ex_exempt` (2671) are unaffected and confirmed correct:
+
+| Field | Originally documented | Corrected | Evidence |
+|---|---|---|---|
+| `ov65s_exempt` | 2660 | **2661** | Offset 2660 is a space character on all 149,225 rows, file-wide — it is never populated, so it cannot be a real flag. Offset 2661 correlates 100% (5/5 sampled rows, plus the file-wide 0.013% rate) with `freeze_exempt_type_cd='OV65S'` and non-zero `ov65_amt` in the entity file. |
+| `dp_exempt` | 2661 | **2662** | Offset 2662 correlates 100% (5/5 sampled rows, plus the file-wide 0.30% rate) with `freeze_exempt_type_cd='DP'`/`'DPS'` and non-zero `dp_amt` in the entity file. |
+| `dv1_exempt`…`dv4s_exempt` | 2662–2670 (9 slots) | **2663–2670 (8 slots)** | Follows directly from the above: once `dp_exempt` is correctly placed at 2662, the disabled-veteran block is the remaining 8 bytes through 2670, which also resolves an odd asymmetry in the original 9-slot range — 8 slots divide cleanly into 4 rating tiers × self/surviving-spouse. Exact per-tier semantic identity (which of the 8 bytes is "10–30% self" vs. "70–100% surviving spouse" etc.) was **not** determined this pass; see caveat below. |
+
+`ex_exempt` (2671) is confirmed correct: all 3 `ex=T` sample rows show `taxable_val=$0` across every taxing entity, consistent with a total exemption.
+
+**`dv_amt` (APPRAISAL_ENTITY_INFO.TXT, offset 344–358) caveat:** this single offset does **not** represent a combined/total disabled-veteran dollar amount. Three sampled properties with a DV-tier flag set show `dv_amt=$12,000` (consistent with the Texas statutory 70–99%-disabled amount), but `000000010097` — which also has a DV-tier flag set (at byte 2669, a *different* position than the other three) — shows `dv_amt=$0` on every entity row while its `taxable_val` is fully zeroed out. The most likely explanation is that PACS keeps **separate** `dv1_amt`/`dv1s_amt`/…/`dv4_amt`/`dv4s_amt` columns (mirroring the 8 DV flags), and this research only located one of them; a 100%-disabled/unemployable veteran's exemption is probably realized through a different column (or through `ex_amt`) rather than through this offset. Do not treat the single `dv_amt` offset documented above as capturing all disabled-veteran exemption dollars — it needs the same kind of per-flag isolation done for `ov65s_exempt`/`dp_exempt` before it's ingest-ready.
+
+### Second flag block (`ab_exempt`…`ch_exempt`, 2723–2731): still unverified
+
+A file-wide frequency scan of offsets 2722–2731 confirms this whole span really is a run of independent `'T'`/`'F'` bytes (not padding) with plausible-looking, individually-varying T-counts (2, 0, 49, 0, 0, 46, 44, 15,203, 0 respectively for offsets 2722–2731). However:
+
+- There is a legitimate, always-`'F'`-but-structurally-real flag byte at **offset 2722**, immediately before the documented `ab_exempt` at 2723, that the original doc's table doesn't account for at all.
+- Unlike the `ov65s`/`dp`/`dv`/`ex` block, there is no independent field in `APPRAISAL_ENTITY_INFO.TXT` sampled in this research (a per-type `ab_amt`, `en_amt`, etc.) to cross-reference these against, the way `freeze_exempt_type_cd` and `ov65_amt`/`dp_amt` caught the error in the first block. The offset-to-specific-name mapping for `ab_exempt`/`en_exempt`/`fr_exempt`/`ht_exempt`/`pro_exempt`/`pc_exempt`/`so_exempt`/`ex366_exempt`/`ch_exempt` is therefore **not confirmed** — it may be correct as documented, or may have the same kind of one-byte drift found in the first block (possibly starting at 2722 instead of 2723). Do not rely on these 9 field names without further verification tying each byte to a real entity-file dollar amount or a live BCAD record known to carry that specific exemption type.
+- The unusually high T-count at whichever offset maps to `ex366_exempt` (15,203/149,225 ≈ 10.2%) initially looked implausible for a "<$500 minimum value" exemption, but on reflection is plausibly explained by a large county with many small mineral-interest/personal-property/utility-easement parcels — this is a plausibility judgment, not a confirmed match, and is called out here rather than silently accepted.
+
+### No-decimal-scaling assumption: confirmed
+
+The original doc verified this against exactly one round-number row (`ov65_amt=$75,000`). This pass adds two more, both **non-round numbers**, which is a much stronger check because a wrong scaling factor would not coincidentally still reconcile the arithmetic:
+
+- `000000010013`, entity S1 (Bryan ISD): `hs_amt`=$100,000 + `ov65_amt`=**$2,946** = $102,946, exactly equal to `assessed_val − taxable_val` ($242,613 − $139,667). If `ov65_amt` carried 2 implied decimal places (like `_money` in `pacs.py`), the raw digits would mean $29.46, not $2,946 — the arithmetic would be off by 100x and would not reconcile. It does reconcile, exactly, as plain dollars.
+- `000000027133`, entity G1 (Brazos County): `ov65_amt`=**$26,935** + `dv_amt`=$12,000 = $38,935, exactly equal to `assessed_val − taxable_val` ($38,935 − $0). Same conclusion.
+
+Both confirm: `APPRAISAL_ENTITY_INFO.TXT`'s `*_amt`/`assessed_val`/`taxable_val` fields are plain, unscaled dollar integers, unlike the 2-implied-decimal money fields elsewhere in this export family. The `_money` helper in `pacs.py` must **not** be reused for these fields if/when this file is wired into `INGEST_SPECS` — a plain-integer cast (or a `_money`-like helper with a scale of 1, not 100) is needed instead.
+
+### Live BCAD cross-check: attempted, not achievable with available tooling
+
+Per the ticket, tried to find and use BCAD's own public per-account search tool as an independent, external cross-check (rather than only cross-referencing the export's internal fields against each other):
+
+- `brazoscad.org`'s homepage has a "PROPERTY SEARCH" button linking to **`https://esearch.brazoscad.org/`** — a real, live, public BCAD property-search portal (not a `propaccess.trueautomation.com` URL as guessed in the ticket; BCAD appears to self-host its own eSearch front-end rather than using True Automation's hosted PropAccess product, even though the certified export itself is True Automation/PACS format).
+- The search UI (By Owner / By Address / By ID / ARB Search / Advanced tabs) is confirmed live and reachable, showing a real disclaimer about "2026 PRELIMINARY VALUES."
+- Attempted direct deep-links to individual property records for sampled `prop_id`s (e.g. `10013`) using several plausible query-string patterns against `Property.aspx` (`?prop_id=10013`, `?PropertyID=10013`, `?p=10013&year=2025`) — **all three returned the site's generic `ERROR 404: Page Not Found` page**, not a valid record and not a "property not found" message specific to that ID (the same generic error appeared for every pattern tried, which is itself the tell).
+- Conclusion: this looks like a standard ASP.NET WebForms search app that generates result links via server-side postback with a session-scoped token, rather than supporting bare `?prop_id=` deep-linking. `WebFetch` (single-shot GET + HTML→markdown, no JavaScript execution, no form POST, no session/cookie continuity across calls) cannot drive that flow. This is a genuine tooling limitation, not a "no exemptions matched" finding — no live BCAD data was actually compared against the byte-offset decoding in this pass.
+- In place of the live cross-check, this pass relied on the internal-consistency method described above (three independently-populated fields — `APPRAISAL_INFO.TXT` flags, `APPRAISAL_ENTITY_INFO.TXT` dollar amounts, and `freeze_exempt_type_cd` — that must agree, and did, across 15 real accounts, catching a real one-byte offset error in the process). That is meaningfully stronger than the original single-field, single-row check, but it is still not the same as an external ground-truth comparison against BCAD's own published per-account record.
+
+### Summary of what changed vs. the original finding
+
+- **Confirmed as originally documented:** `ha_exempt` (2609), `ov65_exempt` (2610), `ex_exempt` (2671); `APPRAISAL_ENTITY_INFO.TXT`'s `prop_id`, `prop_val_yr`, `entity_id`, `entity_cd`, `entity_name`, `assessed_val`, `taxable_val`, `hs_amt`, `ov65_amt`, `dp_amt`, `freeze_exempt_type_cd`; the no-decimal-scaling assumption for File #3's money fields (now checked against 3 rows including 2 non-round numbers, not just 1 round one).
+- **Corrected:** `ov65s_exempt` 2660→2661, `dp_exempt` 2661→2662, DV-tier flags 2662–2670→2663–2670 (8, not 9, slots).
+- **Refined (not wrong, but narrower than implied):** `dv_amt` (344–358) is one of several likely per-tier disabled-veteran amount columns, not a combined total — needs further isolation before ingest.
+- **Still unconfirmed:** the `ab_exempt`…`ch_exempt` block's exact offset-to-name mapping (2722 vs. 2723 start, and no independent field to cross-check the 9 names against).
+- **Not achievable this pass:** live cross-reference against BCAD's own public property-search tool (`esearch.brazoscad.org`) — the site was located and is real/public, but doesn't support the kind of direct per-account deep-linking that the available fetch tooling can drive.

--- a/docs/research/brazos-gis-parcel-shapefile.md
+++ b/docs/research/brazos-gis-parcel-shapefile.md
@@ -1,0 +1,55 @@
+# Brazos GIS parcel shapefile characterization
+
+Research for [wayfinder ticket #7](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/7) on the [Brazos County tax-analysis parity map](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/3).
+
+## Question
+
+Characterize the Brazos GIS parcel shapefile's schema for lat/long coordinate ingestion, mirroring Harris's `load_gis_data` / `Parcels.zip` pipeline.
+
+## Source
+
+`https://brazoscad.org/wp-content/uploads/2026/05/BrazosCADParcels_20260422.zip` (found via `brazoscad.org/tax-information/gis/` — the filename guessed during ticket charting was close but not exact; the download page is the reliable way to find the current year's link). 27MB zip, standard Esri shapefile bundle (`.shp`/`.shx`/`.dbf`/`.prj`/`.cpg`/`.sbn`/`.sbx` + a `.shp.xml` metadata file). **77,433 features.**
+
+## Coordinate reference system
+
+`EPSG:2277` — NAD83 / Texas Central (US feet). Needs reprojection to WGS84 (`EPSG:4326`) for lat/long, the same as Harris's pipeline already does (see `docs/guides/GIS.md`). Verified: centroid reprojection of 3 sample parcels lands at real Bryan, TX coordinates (~30.68°N, -96.37°W), confirming the transform is correct.
+
+## Join key
+
+`PROP_ID` (also duplicated as `prop_id_1`) — a **plain integer** (e.g. `10002`), NOT the zero-padded 12-char string `brazos_cad.PropertyAccount.prop_id` uses (`"000000010002"`). Needs `int()`/zero-pad conversion when joining. Confirmed present and populated on essentially all 77,433 features.
+
+## Full attribute field list
+
+```
+PROP_ID, last_edite, prop_id_1, geo_id, Sale_Date, sl_price, sl_ratio, file_as_na,
+addr_line1, addr_line2, addr_line3, addr_city, addr_state, addr_zip,
+situs_num, situs_stre, situs_st_1, situs_st_2, situs_unit,
+legal_desc, abs_subdv_, Deed_Date, deed_book_, deed_book1, sl_type_cd, hood_cd,
+Entities, Exemptions,
+market, Land_Val, Imprv_Val, state_cd, ls_table, land_acres, land_sqft,
+living_are, class_cd, imprv_unit, yr_built, yr_blt, land_unit_,
+ImpCnt, Group_Code, Group_Co_1, Group_Co_2,
+Shape_Leng, Shape_Area, geometry
+```
+
+## What this answers on the map (see individual ticket docs for full detail)
+
+- **[Ticket #4](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/4) (situs address)** — `situs_num`/`situs_stre`/`situs_st_1`/`situs_st_2`/`situs_unit` = the true physical address, distinct from `addr_line1`/`addr_city`/`addr_state`/`addr_zip` (the mailing address, confirmed to exactly match what's already decoded from `APPRAISAL_INFO.TXT`). 99.65% populated (77,165/77,433). See [docs/research/brazos-situs-address.md](https://github.com/PorkChopExpress86/TaxProtest-Django/blob/research/brazos-situs-address/docs/research/brazos-situs-address.md).
+- **[Ticket #5](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/5) (values + state_class)** — `market`, `Land_Val`, `Imprv_Val`, `state_cd` all present as clean typed fields, no fixed-width decoding needed. `Land_Val + Imprv_Val == market` exactly on a 2,000-row sample, **0 mismatches**. `state_cd` distribution looks like real Texas property-class codes (A1 dominant at 48,195 rows — plausibly residential; also C1/F1/A7/E1/A2/B2/D1/A8/E4/etc). See [docs/research/brazos-values.md](https://github.com/PorkChopExpress86/TaxProtest-Django/blob/research/brazos-values/docs/research/brazos-values.md).
+- **[Ticket #6](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/6) (building characteristics)** — `living_are` (sqft), `yr_built`/`yr_blt` (age — cross-validates *exactly* against this codebase's own independently-derived `year_built` rollup for a real test property: both give 1980), `class_cd` (quality/construction-type-like code, values like `RV3`/`RF4`/`RV4P` suggest R=residential, V/F=veneer/frame, digit=quality tier, P=partial — not fully confirmed). **No bedroom or bathroom field anywhere in this shapefile** — those come only from `APPRAISAL_IMPROVEMENT_DETAIL_ATTR.TXT` (see [docs/research/brazos-building-characteristics.md](https://github.com/PorkChopExpress86/TaxProtest-Django/blob/research/brazos-building-characteristics/docs/research/brazos-building-characteristics.md)), already resolved. `ImpCnt` (improvement count) exists but isn't a real substitute for "stories" — still unconfirmed.
+- **Ticket #8 (entity tax rates)** — not investigated for overlap in this pass; the shapefile has `Entities`/`Exemptions` list-like text fields per parcel, but no rate percentage was spotted in a quick glance. Resolved separately/externally — see [docs/research/brazos-entity-tax-rates.md](https://github.com/PorkChopExpress86/TaxProtest-Django/blob/research/brazos-entity-tax-rates/docs/research/brazos-entity-tax-rates.md).
+
+## Cross-validation against the test property used throughout this codebase's Brazos work
+
+`prop_id=000000010002` (STASNY FAMILY RANCH LLC):
+
+- Mailing (shapefile `addr_line1`/`addr_city`/`addr_state`/`addr_zip`): blank / "COLLEGE STATION" / "TX" / "77845-8087" — **exactly matches** what's already decoded from `APPRAISAL_INFO.TXT`, confirming that block really is mailing address, as suspected.
+- Situs (shapefile `situs_num`/`situs_st_1`/`situs_st_2`): "5000 SILVER HILL RD" — a distinct, plausible rural address for a ranch property, genuinely different from the mailing address.
+- Values: `market`=$5,501,797, `Land_Val`=$5,081,302, `Imprv_Val`=$420,495 — consistent with a large ranch property (`land_acres`=573.9).
+- `yr_built`=1980 — matches this codebase's own independently-computed `year_built` rollup (from `PropertyImprovementDetail`) for the same property exactly.
+
+## Not yet done
+
+This ticket was characterization only — no ingestion command was designed or built. Whoever picks this up next should mirror Harris's `load_gis_data` pattern (see `data/management/commands/load_gis_data.py` and `docs/guides/GIS.md`), reproject `EPSG:2277` → `EPSG:4326`, and reconcile the `PROP_ID` zero-padding mismatch against `PropertyAccount.prop_id`.
+
+The raw shapefile was downloaded to a session-only temp path during this research (not committed, not on a durable path) — re-download from the source URL above when implementing.

--- a/docs/research/brazos-situs-address.md
+++ b/docs/research/brazos-situs-address.md
@@ -1,0 +1,52 @@
+# Brazos true situs (property) address
+
+Research for [wayfinder ticket #4](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/4) on the [Brazos County tax-analysis parity map](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/3).
+
+## Question
+
+Where does BCAD's data carry the property's TRUE situs (physical) address, distinct from the owner-mailing-address block already decoded at `APPRAISAL_INFO.TXT` offsets 753:987 — which is what `/brazos/` incorrectly shows today?
+
+## Finding: not in `APPRAISAL_INFO.TXT` at all — it's in the GIS parcel shapefile
+
+### `APPRAISAL_INFO.TXT` confirmed to have no second situs block
+
+Scanned every byte offset across 5,000+ sample rows in `var/bcad_extracted/2025/2025-07-23_002022_APPRAISAL_INFO.TXT` for (a) Brazos-area city name strings and (b) 77xxx/78xxx zip patterns. Found only:
+
+- The known mailing block at offset 873 (city) / 978 (zip).
+- An exact duplicate of the identical values at a fixed +3968-byte shift (offset 4741/4846) — confirmed byte-identical to the primary block across 1,978 of 1,978 sampled rows. This is a duplicate of the mailing block, not a distinct situs field.
+
+No other offset — including the unexplored 5000–9247 tail — showed city-name or zip hits above ~2% of rows (noise/coincidence threshold). This file genuinely does not carry situs address anywhere in its decodable text.
+
+### The real situs address lives in the BCAD GIS parcel shapefile
+
+Full schema/CRS/join-key detail is in [docs/research/brazos-gis-parcel-shapefile.md](./brazos-gis-parcel-shapefile.md) (ticket #7's dedicated characterization) — summary here.
+
+Source: `https://brazoscad.org/wp-content/uploads/2026/05/BrazosCADParcels_20260422.zip` (linked from `brazoscad.org/tax-information/gis/`), 77,433 parcel records. Its `.dbf` attribute table has explicit, separate, structured fields for situs vs. mailing address:
+
+**Situs (physical) address fields**: `situs_num`, `situs_stre` (direction), `situs_st_1` (street name), `situs_st_2` (suffix), `situs_unit`. 99.65% populated (77,165/77,433).
+
+**Mailing address fields** (separate, confirmed distinct): `addr_line1` (often a "% AGENT NAME" c/o line, e.g. `'% RODRIGUEZ MARIE P AGENT'`), `addr_city`, `addr_state`, `addr_zip`.
+
+**Join key**: `PROP_ID` (also duplicated as `prop_id_1`) — a plain integer (e.g. `10002`), **not** zero-padded to 12 digits like the `prop_id` used elsewhere in `brazos_cad` (e.g. `'000000010002'`). Format reconciliation needed when joining against `PropertyAccount.prop_id`.
+
+**Cross-validated directly against the test property used throughout this codebase's Brazos work** (`prop_id=000000010002`, STASNY FAMILY RANCH LLC):
+
+- Mailing (shapefile): blank / "COLLEGE STATION" / "TX" / "77845-8087" — **exactly matches** what's already decoded from `APPRAISAL_INFO.TXT`, confirming that block really is mailing address, as suspected.
+- Situs (shapefile): "5000 SILVER HILL RD" — a distinct, plausible rural address for a ranch property, genuinely different from the mailing address.
+
+A second example (prop `22567`, Cavitt Janice Jean) shows the same pattern: mailing = "605 N PARKER AVE", situs = "206 W 21ST ST" — different addresses again.
+
+## Recommendation
+
+Whoever implements the fix should use the shapefile's `situs_num`/`situs_stre`/`situs_st_1`/`situs_st_2`/`situs_unit` fields, not `APPRAISAL_INFO.TXT`. `APPRAISAL_INFO`'s address block should stay labeled as owner mailing address (or be dropped from the public-facing "Address" column and replaced by this shapefile data).
+
+## Related findings (out of scope for this ticket, surfaced incidentally)
+
+The same shapefile inspection also found data directly relevant to two sibling tickets:
+
+- **[Ticket #5](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/5) (values/state_class)**: the shapefile has `market`, `Land_Val`, `Imprv_Val` (clean typed numeric fields, e.g. `market=147770, Land_Val=79542, Imprv_Val=68228`) and `state_cd` (e.g. `'A1'`, `'F1'`, `'C1'`) — see [docs/research/brazos-values.md](./brazos-values.md) for the full resolution.
+- **[Ticket #6](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/6) (building characteristics)**: `living_are` (sqft, e.g. `1608`), `yr_blt` (e.g. `1991`), `class_cd` (e.g. `'RF1'`, `'RF2P'`) — folded into [docs/research/brazos-building-characteristics.md](./brazos-building-characteristics.md).
+
+See [ticket #7](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/7) (dedicated GIS shapefile characterization) for the authoritative full field list, CRS, and row count.
+
+The raw shapefile was downloaded to a session-only temp path during this research (not committed, not on a durable path) — whoever implements ingestion will need to re-download it from the URL above.

--- a/docs/research/brazos-values.md
+++ b/docs/research/brazos-values.md
@@ -1,0 +1,46 @@
+# Brazos assessed/total/market value + state_class
+
+Research for [wayfinder ticket #5](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/5) on the [Brazos County tax-analysis parity map](https://github.com/PorkChopExpress86/TaxProtest-Django/issues/3).
+
+## Question (as originally scoped)
+
+Decode `total_value`, `land_value`, `improvement_value`, `assessed_value`, and `state_class` from `APPRAISAL_INFO.TXT`'s undecoded rollup region, ~byte offset 1745–2200 of the 9,247-char record.
+
+## Finding: the original approach was a dead end — the GIS parcel shapefile answers this directly instead
+
+### Attempt 1: decoding `APPRAISAL_INFO.TXT`'s rollup region — inconclusive, abandoned
+
+The region from offset ~1795 onward is confirmed dense/structured — uniform 15-char zero-padded numeric slots, a flag character, two shorter numeric/comma-formatted fields (likely legal-description/plat references, not values — e.g. `873,1366`, `210,073`), an 8-digit `MMDDYYYY` date (likely a deed date), then more reserved zero fields.
+
+Two candidate offsets were found with **high confidence but the wrong semantics**:
+- Offset `1855:1870` (÷10000) matches a land segment's acreage.
+- Offset `1870:1885` (÷100) matches a land segment's `land_value`.
+
+But cross-checking against the already-ingested database (`PropertyLand` grouped by `prop_id`) showed these are **per-segment values, not property-wide totals** — a multi-parcel property (common in this rural county) has this offset holding only its *first* segment's value, not the sum. Not usable as "the property's land_value."
+
+Two more candidate offsets (`1840:1855` for `improvement_value`; `1915:1930`/`1945:1960` for `total_value`/`assessed_value`) looked plausible on one anchor row, but the hypothesis `land + improvement = total` held for only 1,117 of 5,000 sampled rows (22%) — not reliable. Cross-checking a specific property (`prop_id=000000010011`) showed the candidate total (`22,379.52`) didn't reconcile with summed real data at all (off by orders of magnitude from a `PropertyImprovementDetail.detail_value` sum of `1,608,845.00`).
+
+`state_class` was not located anywhere near this block — no alphanumeric 2-4 char code resembling Texas state-class codes turned up.
+
+**Conclusion**: `APPRAISAL_INFO.TXT`'s 9,247-char record most likely encodes value data per-segment (per land parcel / per improvement), not as simple property-wide rollups — the record probably isn't "one row = one property with everything summed" the way the original ticket assumed. Confidently decoding this further would need figuring out the record's full repeating-segment structure, which is a much bigger undertaking than the rest of this file's decode.
+
+### Attempt 2: the GIS parcel shapefile — answered directly, no further decoding needed
+
+Full schema/CRS/join-key detail is in [docs/research/brazos-gis-parcel-shapefile.md](https://github.com/PorkChopExpress86/TaxProtest-Django/blob/research/brazos-gis-parcel-shapefile/docs/research/brazos-gis-parcel-shapefile.md) (ticket #7's dedicated characterization). Source: `https://brazoscad.org/wp-content/uploads/2026/05/BrazosCADParcels_20260422.zip`.
+
+The shapefile's `.dbf` attribute table has `market`, `Land_Val`, `Imprv_Val`, and `state_cd` as **clean, already-typed fields** — no byte-offset decoding required at all:
+
+- `market` — total value
+- `Land_Val` — land value
+- `Imprv_Val` — improvement value
+- `state_cd` — property class code (e.g. `A1`, `C1`, `F1`, `A7`, `E1`, `A2`, `B2`, `D1`, `A8`, `E4`)
+
+**Rigorously validated**: `Land_Val + Imprv_Val == market` exactly, checked across a 2,000-row sample — **0 mismatches**. All value fields 100% populated; `state_cd` 99.65% populated. `state_cd` distribution looks like real Texas property-class codes, with `A1` dominant (48,195 of ~77,433 rows — plausibly residential).
+
+Cross-validated against the test property used throughout this codebase's Brazos work (`prop_id=000000010002`, STASNY FAMILY RANCH LLC, a ranch property with `land_acres`=573.9): `market`=$5,501,797, `Land_Val`=$5,081,302, `Imprv_Val`=$420,495 — internally consistent and plausible for the property type.
+
+## Recommendation
+
+Use the GIS parcel shapefile's `market`/`Land_Val`/`Imprv_Val`/`state_cd` fields, not `APPRAISAL_INFO.TXT`'s undecoded region. This also means `is_residential` (currently unpopulated on `PropertyAccount`) becomes derivable once `state_cd` is ingested, the same way Harris derives it from `state_class`.
+
+No `APPRAISAL_INFO.TXT` decoding work remains necessary for this ticket's original goal — the per-segment structure issue documented in Attempt 1 is noted for completeness but doesn't block anything now that the shapefile answers the question directly.


### PR DESCRIPTION
Three small corrections, stacked on #29. No behaviour change.

## Load counts report what landed, not what was offered

Every ORM loader passes `ignore_conflicts=True`, so a row whose key already exists is dropped silently — but `records_loaded` counted rows *handed to* `bulk_create`. It read like a completeness signal while overstating one: on a real HCAD run `extra_features_detail1` reported **905,338 loaded against 871,769 actually in the table**.

`records_loaded` is now a row-count delta measured inside the transaction, and the 33,569-row gap surfaces as `records_conflicted` rather than being absorbed — it counts duplicate keys in the source, which is worth seeing.

The COPY paths never had this problem and are unchanged; they already reported exactly what landed.

## `refresh_property_readiness` returns a `ReadinessSummary`

The field names were already a contract — `reconcile_property_data` prints `ready_properties_set` to users — but an untyped dict left that discoverable only by reading the function body.

## The `docs/research/` references resolve again

Six code comments and CLAUDE.md point at research notes explaining why Brazos values, coordinates, situs addresses and building characteristics come from where they do. Those notes were only ever committed to their own `research/*` branches, so **every reference dangled**.

Restored the six files as-is. The branches themselves are ~19k lines behind main and are not worth merging — this takes the documentation and leaves them alone. Verified transitively: the restored docs cross-reference each other, which surfaced two more files than the first sweep found.

## Verification

453 tests (+1), ruff, mypy, no pending migrations. The new load-count test was checked to fail without its fix — with the old accounting it reports "Loaded 3" when one row landed.

> A fourth item from the same list — dropping `ParcelGeometry.parcel_id` — went to #28 instead, since it needs a migration and #28 is already the dead-column drop. Putting it here would have created a second `0019` and conflicting leaf migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)